### PR TITLE
Support creating a Git tag and exporting tarball from the tag.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2017-12-07 Ivan Vucica <ivan@vucica.net>
+
+	* Master/source-distribution.make: Allow creating a Git tag and
+	creating a tarball from a git tag.
+
 2017-04-14 Richard Frith-Macdonald <rfm@gnu.org>
 
 	* Version: 2.7.0 release

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,8 @@
 
 	* Master/source-distribution.make: Allow creating a Git tag and
 	creating a tarball from a git tag.
+	* GNUmakefile.in: Allow creating a Git tag and creating a tarball
+	from a Git tag, for releasing gnustep-make itself.
 
 2017-04-14 Richard Frith-Macdonald <rfm@gnu.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2017-12-10 Ivan Vucica <ivan@vucica.net>
+
+	* Master/source-distribution.make
+	* GNUmakefile.in:
+	When adding an ANNOUNCE file to the annotated tag, added dependency
+	on the passed ANNOUNCE file to ensure the temporary file which
+	prepends 'Release x.yz' gets regenerated while tagging.
+
 2017-12-07 Ivan Vucica <ivan@vucica.net>
 
 	* Master/source-distribution.make: Allow creating a Git tag and

--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -418,6 +418,49 @@ cvs-snapshot:
 	tar --gzip -cf gnustep-make-$(GNUSTEP_MAKE_VERSION).tar.gz gnustep-make-$(GNUSTEP_MAKE_VERSION)
 	rm -rf gnustep-make-$(GNUSTEP_MAKE_VERSION)
 
+ifeq ($(GIT_TAG_SIGN), )
+GIT_TAG_ANNOTATION_FLAGS = -a
+else
+  ifeq ($(GIT_TAG_SIGN), yes)
+  GIT_TAG_ANNOTATION_FLAGS = -s
+  else
+  GIT_TAG_ANNOTATION_FLAGS = -u $(GIT_TAG_SIGN)
+  endif
+endif
+
+git-tag-stable:
+	echo "*Error* tagging stable branch in Git is not supported at this time." && exit 1
+
+ifeq ($(GIT_TAG_ANNOUNCE_FILE),)
+git-tag:
+	git tag \
+	  $(GIT_TAG_ANNOTATION_FLAGS) \
+	  make-$(VERTAG) \
+	  -m "Release $(GNUSTEP_MAKE_VERSION)."
+else
+ifneq ($(GIT_TAG_ANNOUNCE_OMIT_PREFACE),yes)
+.INTERMEDIATE += git-tag-announce-file.tmp
+git-tag-announce-file.tmp:
+	printf "Release $(GNUSTEP_MAKE_VERSION).\n\n" > git-tag-announce-file.tmp
+	cat $(GIT_TAG_ANNOUNCE_FILE) >> git-tag-announce-file.tmp
+
+git-tag: git-tag-announce-file.tmp
+	git tag \
+	  $(GIT_TAG_ANNOTATION_FLAGS) \
+	  make-$(VERTAG) \
+	  -F git-tag-announce-file.tmp
+else
+git-tag:
+	git tag \
+	  $(GIT_TAG_ANNOTATION_FLAGS) \
+	  make-$(VERTAG) \
+	  -F $(GIT_TAG_ANNOUNCE_FILE)
+endif
+endif
+
+git-dist:
+	git archive --format=tar.gz make-$(VERTAG) -o gnustep-make-$(GNUSTEP_MAKE_VERSION).tar.gz --prefix=gnustep-make-$(GNUSTEP_MAKE_VERSION)/
+
 test-RPM_TOPDIR:
 	@(if [ -z "$(RPM_TOPDIR)" ]; then                                  \
 	  echo "Error - RPM_TOPDIR variable not set.";                     \

--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -439,16 +439,16 @@ git-tag:
 	  -m "Release $(GNUSTEP_MAKE_VERSION)."
 else
 ifneq ($(GIT_TAG_ANNOUNCE_OMIT_PREFACE),yes)
-.INTERMEDIATE += git-tag-announce-file.tmp
-git-tag-announce-file.tmp:
-	printf "Release $(GNUSTEP_MAKE_VERSION).\n\n" > git-tag-announce-file.tmp
-	cat $(GIT_TAG_ANNOUNCE_FILE) >> git-tag-announce-file.tmp
+.INTERMEDIATE += git-tag-announce-file_$(GNUSTEP_MAKE_VERSION).tmp
+git-tag-announce-file_$(GNUSTEP_MAKE_VERSION).tmp: $(GIT_TAG_ANNOUNCE_FILE)
+	printf "Release $(GNUSTEP_MAKE_VERSION).\n\n" > $@
+	cat $(GIT_TAG_ANNOUNCE_FILE) >> $@
 
-git-tag: git-tag-announce-file.tmp
+git-tag: git-tag-announce-file_$(GNUSTEP_MAKE_VERSION).tmp
 	git tag \
 	  $(GIT_TAG_ANNOTATION_FLAGS) \
 	  make-$(VERTAG) \
-	  -F git-tag-announce-file.tmp
+	  -F $<
 else
 git-tag:
 	git tag \

--- a/Master/source-distribution.make
+++ b/Master/source-distribution.make
@@ -409,16 +409,16 @@ git-tag:
 	  -m "Release $(PACKAGE_VERSION)"
 else
 ifneq ($(GIT_TAG_ANNOUNCE_OMIT_PREFACE),yes)
-.INTERMEDIATE += git-tag-announce-file.tmp
-git-tag-announce-file.tmp:
-	printf "Release $(PACKAGE_VERSION).\n\n" > git-tag-announce-file.tmp
-	cat $(GIT_TAG_ANNOUNCE_FILE) >> git-tag-announce-file.tmp
+.INTERMEDIATE += git-tag-announce-file-$(VERTAG).tmp
+git-tag-announce-file-$(VERTAG).tmp: $(GIT_TAG_ANNOUNCE_FILE)
+	printf "Release $(PACKAGE_VERSION).\n\n" > $@
+	cat $(GIT_TAG_ANNOUNCE_FILE) >> $@
 
-git-tag: git-tag-announce-file.tmp
+git-tag: git-tag-announce-file-$(VERTAG).tmp
 	$(GIT) tag \
 	  $(GIT_TAG_ANNOTATION_FLAGS) \
 	  $(GIT_TAG_NAME)-$(VERTAG) \
-	  -F git-tag-announce-file.tmp
+	  -F $<
 else
 git-tag:
 	$(GIT) tag \


### PR DESCRIPTION
This adds support for git-tag and git-dist of both gnustep-make and other tools that may be using it. Can you please take a look and assess whether there's any glaring issue?

I'll be using this to cut the -gui release soon.