### PR TITLE
Fix extract class names for runtime 2.0 (Linux only)

### DIFF
--- a/target.make
+++ b/target.make
@@ -156,16 +156,23 @@ endif
 # with XXXX, and prints the result. '-n' disables automatic printing
 # for portability, so we are sure we only print what we want on all
 # platforms.
+
+USING_GNUSTEP_RUNTIME_VERSION_GTE_2_0 := false
 ifdef RUNTIME_VERSION
-RUNTIME_VERSION_NUMBER :=$(shell echo $(RUNTIME_VERSION) | cut -f2 -d"-")
-RUNTIME_VERSION_MAJOR := $(shell echo $(RUNTIME_VERSION_NUMBER) | cut -f1 -d.)
-RUNTIME_VERSION_MINOR := $(shell echo $(RUNTIME_VERSION_NUMBER) | cut -f2 -d.)
-RUNTIME_VERSION_GTE_2_0 := $(shell [ $(RUNTIME_VERSION_MAJOR) -gt 2 -o $(RUNTIME_VERSION_MAJOR) -eq 2 ] && echo true)
-else
-RUNTIME_VERSION_GTE_2_0 := false
+  RUNTIME_VERSION_NUMBER :=$(shell echo $(RUNTIME_VERSION) | cut -f2 -d"-")
+  RUNTIME_VERSION_MAJOR := $(shell echo $(RUNTIME_VERSION_NUMBER) | cut -f1 -d.)
+  RUNTIME_VERSION_MINOR := $(shell echo $(RUNTIME_VERSION_NUMBER) | cut -f2 -d.)
+  RUNTIME_VERSION_GTE_2_0 := $(shell [ $(RUNTIME_VERSION_MAJOR) -gt 2 -o $(RUNTIME_VERSION_MAJOR) -eq 2 ] && echo true)
+  ifeq ($(findstring gnustep,$(RUNTIME_VERSION)), gnustep)
+    ifeq ($(RUNTIME_VERSION_GTE_2_0), true)
+      USING_GNUSTEP_RUNTIME_VERSION_GTE_2_0 := true
+    endif
+  endif
 endif
 
-ifeq ($(RUNTIME_VERSION_GTE_2_0),true)
+
+
+ifeq ($(USING_GNUSTEP_RUNTIME_VERSION_GTE_2_0),true)
 EXTRACT_CLASS_NAMES_COMMAND = $(NM) -Pg $$object_file | sed -n -e '/^._OBJC_CLASS_[A-Za-z0-9_.]* [^U]/ {s/^._OBJC_CLASS_\([A-Za-z0-9_.]*\) [^U].*/\1/p;}'
 else
 EXTRACT_CLASS_NAMES_COMMAND = $(NM) -Pg $$object_file | sed -n -e '/^__objc_class_name_[A-Za-z0-9_.]* [^U]/ {s/^__objc_class_name_\([A-Za-z0-9_.]*\) [^U].*/\1/p;}'

--- a/target.make
+++ b/target.make
@@ -157,26 +157,13 @@ endif
 # for portability, so we are sure we only print what we want on all
 # platforms.
 
-USING_GNUSTEP_RUNTIME_VERSION_GTE_2_0 := false
-ifdef RUNTIME_VERSION
-  RUNTIME_VERSION_NUMBER :=$(shell echo $(RUNTIME_VERSION) | cut -f2 -d"-")
-  RUNTIME_VERSION_MAJOR := $(shell echo $(RUNTIME_VERSION_NUMBER) | cut -f1 -d.)
-  RUNTIME_VERSION_MINOR := $(shell echo $(RUNTIME_VERSION_NUMBER) | cut -f2 -d.)
-  RUNTIME_VERSION_GTE_2_0 := $(shell [ $(RUNTIME_VERSION_MAJOR) -gt 2 -o $(RUNTIME_VERSION_MAJOR) -eq 2 ] && echo true)
-  ifeq ($(findstring gnustep,$(RUNTIME_VERSION)), gnustep)
-    ifeq ($(RUNTIME_VERSION_GTE_2_0), true)
-      USING_GNUSTEP_RUNTIME_VERSION_GTE_2_0 := true
-    endif
-  endif
-endif
 
+#
+# NB. With the gnustep-2.0 ABI the class name prefix is ._OBJC_CLASS_
+# rather than __objc_class_name_ so we search for either.
+#
+EXTRACT_CLASS_NAMES_COMMAND = $(NM) -Pg $$object_file | sed -n -e '/^__objc_class_name_[A-Za-z0-9_.]* [^U]/ {s/^__objc_class_name_\([A-Za-z0-9_.]*\) [^U].*/\1/p;}' -e '/^\._OBJC_CLASS_[A-Za-z0-9_.]* [^U]/ {s/^\._OBJC_CLASS_\([A-Za-z0-9_.]*\) [^U].*/\1/p;}'
 
-
-ifeq ($(USING_GNUSTEP_RUNTIME_VERSION_GTE_2_0),true)
-EXTRACT_CLASS_NAMES_COMMAND = $(NM) -Pg $$object_file | sed -n -e '/^._OBJC_CLASS_[A-Za-z0-9_.]* [^U]/ {s/^._OBJC_CLASS_\([A-Za-z0-9_.]*\) [^U].*/\1/p;}'
-else
-EXTRACT_CLASS_NAMES_COMMAND = $(NM) -Pg $$object_file | sed -n -e '/^__objc_class_name_[A-Za-z0-9_.]* [^U]/ {s/^__objc_class_name_\([A-Za-z0-9_.]*\) [^U].*/\1/p;}'
-endif
 
 #
 # This is the generic version - if the target is not in the following list,

--- a/target.make
+++ b/target.make
@@ -156,7 +156,20 @@ endif
 # with XXXX, and prints the result. '-n' disables automatic printing
 # for portability, so we are sure we only print what we want on all
 # platforms.
+ifdef RUNTIME_VERSION
+RUNTIME_VERSION_NUMBER :=$(shell echo $(RUNTIME_VERSION) | cut -f2 -d"-")
+RUNTIME_VERSION_MAJOR := $(shell echo $(RUNTIME_VERSION_NUMBER) | cut -f1 -d.)
+RUNTIME_VERSION_MINOR := $(shell echo $(RUNTIME_VERSION_NUMBER) | cut -f2 -d.)
+RUNTIME_VERSION_GTE_2_0 := $(shell [ $(RUNTIME_VERSION_MAJOR) -gt 2 -o $(RUNTIME_VERSION_MAJOR) -eq 2 ] && echo true)
+else
+RUNTIME_VERSION_GTE_2_0 := false
+endif
+
+ifeq ($(RUNTIME_VERSION_GTE_2_0),true)
+EXTRACT_CLASS_NAMES_COMMAND = $(NM) -Pg $$object_file | sed -n -e '/^._OBJC_CLASS_[A-Za-z0-9_.]* [^U]/ {s/^._OBJC_CLASS_\([A-Za-z0-9_.]*\) [^U].*/\1/p;}'
+else
 EXTRACT_CLASS_NAMES_COMMAND = $(NM) -Pg $$object_file | sed -n -e '/^__objc_class_name_[A-Za-z0-9_.]* [^U]/ {s/^__objc_class_name_\([A-Za-z0-9_.]*\) [^U].*/\1/p;}'
+endif
 
 #
 # This is the generic version - if the target is not in the following list,


### PR DESCRIPTION
With Runtime 2.0, the text next to classes as discovered by this nm command changed.
This prevented NSBundles from being loaded from their location.

This pull request addresses those changes for Linux. With this solution, ProjectCenter is able to correctly load bundles when built under Runtime 2.0, and the LogPanel shows up during startup.
Without this change, ProjectCenter cannot load its bundles, and the LogPanel does not appear. 