### PR TITLE
Normalize annoucement file between core libraries

### DIFF
--- a/ANNOUNCE
+++ b/ANNOUNCE
@@ -3,7 +3,7 @@
 
 The GNUstep Makefile Package version 2.8.0 is now available.
 
-1.1 What is the GNUstep makefile package?
+1.1 What is the GNUstep Makefile Package?
 =========================================
 
 The makefile package is a simple, powerful and extensible way to write
@@ -48,9 +48,32 @@ compatible
 1.4 Obtaining gnustep-make
 ==========================
 
-You can get the gstep-make-2.8.0.tar.gz distribution file at
+You can get the gnustep-make-2.8.0.tar.gz distribution file at
 <ftp://ftp.gnustep.org/pub/gnustep/core>
 
-   Please log bug reports on the GNUstep project page
+   It is accompanied by gnustep-make-2.8.0.tar.gz.sig, a PGP signature
+which you can validate by putting both files in the same directory and
+using:
+
+     gpg --verify gnustep-make-2.8.0.tar.gz.sig
+
+   Signature has been created using the key with the following
+fingerprint:
+
+     83AA E47C E829 A414 6EF8  3420 CA86 8D4C 9914 9679
+
+   Read the INSTALL file or the GNUstep-HOWTO for installation
+instructions.
+
+1.5 Where do I send bug reports?
+================================
+
+Please log bug reports on the GNUstep project page
 <http://savannah.gnu.org/bugs/?group=gnustep> or send bug reports to
 <bug-gnustep@gnu.org>.
+
+1.6 Obtaining GNUstep Software
+==============================
+
+Check out the GNUstep web site.  (<http://www.gnustep.org/>) and the GNU
+web site.  (<http://www.gnu.org/>)

--- a/ANNOUNCE
+++ b/ANNOUNCE
@@ -31,21 +31,7 @@ the user to easily create cross-compiled binaries.
 
    * Dropped legacy Rhapsody and FreeBSD-out support.
 
-1.3 Changes in version '2.7.0'
-==============================
-
-Garbage collection support removed
-
-   ARC enabled by default if the ng runtime is used
-
-   Multi-architecture directory layout adjusted to be more Debian
-compatible
-
-   Framework support fixes
-
-   Various other minor bugfixes
-
-1.4 Obtaining gnustep-make
+1.3 Obtaining gnustep-make
 ==========================
 
 You can get the gnustep-make-2.8.0.tar.gz distribution file at

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2020-04-13  Ivan Vucica <ivan@vucica.net>
+
+	* Documentation/announce.texi:
+	* ANNOUNCE:
+	Normalize the accompanying text for the release announcement across
+	core packages: standardize chapter name and GPG information.
+
 2020-04-05  Ivan Vucica <ivan@vucica.net>
 
 	* ANNOUNCE:

--- a/Documentation/announce.texi
+++ b/Documentation/announce.texi
@@ -1,10 +1,11 @@
+@c -*- texinfo -*-
 @chapter Announcement
 
 @include version.texi
 
 The GNUstep Makefile Package version @value{GNUSTEP-MAKE-VERSION} is now available.
 
-@section What is the GNUstep makefile package?
+@section What is the GNUstep Makefile Package?
 
 The makefile package is a simple, powerful and extensible way to
 write makefiles for a GNUstep-based project.  It allows the user to
@@ -18,9 +19,32 @@ It also allows the user to easily create cross-compiled binaries.
 
 @section Obtaining gnustep-make
 
-You can get the gstep-make-@value{GNUSTEP-MAKE-VERSION}.tar.gz
+You can get the gnustep-make-@value{GNUSTEP-MAKE-VERSION}.tar.gz
 distribution file at @url{ftp://ftp.gnustep.org/pub/gnustep/core}
+
+It is accompanied by gnustep-make-@value{GNUSTEP-MAKE-VERSION}.tar.gz.sig, a
+PGP signature which you can validate by putting both files in the same
+directory and using:
+
+@example
+gpg --verify gnustep-make-@value{GNUSTEP-MAKE-VERSION}.tar.gz.sig
+@end example
+
+Signature has been created using the key with the following fingerprint:
+
+@example
+83AA E47C E829 A414 6EF8  3420 CA86 8D4C 9914 9679
+@end example
+
+Read the INSTALL file or the GNUstep-HOWTO for installation instructions.
+
+@section Where do I send bug reports?
 
 Please log bug reports on the GNUstep project page
 @url{http://savannah.gnu.org/bugs/?group=gnustep} or send bug
 reports to @email{bug-gnustep@@gnu.org}.
+
+@section Obtaining GNUstep Software
+
+Check out the GNUstep web site. (@url{http://www.gnustep.org/}) and the
+GNU web site. (@url{http://www.gnu.org/})

--- a/Documentation/news.texi
+++ b/Documentation/news.texi
@@ -30,6 +30,8 @@ tag using the @code{hg-tag} and @code{hg-dist} targets.
 
 @end itemize
 
+@ifclear ANNOUNCE-ONLY
+
 @section Changes in version @samp{2.7.0}
 
 Garbage collection support removed
@@ -41,8 +43,6 @@ Multi-architecture directory layout adjusted to be more Debian compatible
 Framework support fixes
 
 Various other minor bugfixes
-
-@ifclear ANNOUNCE-ONLY
 
 @section Changes in version @samp{2.6.8}
 


### PR DESCRIPTION
While preparing the email, I noticed the ANNOUNCE file for `-make` doesn't mention the GPG key, and there are other subtle differences.

I'm creating this pull request across `make`, `base`, `gui` and `back`.

n.b.: `make` is a special case because it doesn't mention `GNUSTEP-MAKE-FTP-MACHINE` and I don't see a point in introducing that.