### PR TITLE
* gs_gcc_version.m4: Add -dumpfullversion to the version

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2020-06-07 Fred Kiefer <FredKiefer@gmx.de>
+
+	* gs_gcc_version.m4: Add -dumpfullversion to the version
+	extraction. Versions of gcc > 7.0 require this parameter to output
+	the full version number. Older versions should just ignore this option.
+	* configure: Regenerate
+
 2020-04-14  Yavor Doganov  <yavor@gnu.org>
 
 	* config-precomp-test/run-test.sh: Put $LIBS at the end so that it

--- a/configure
+++ b/configure
@@ -748,6 +748,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -849,6 +850,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE}'
@@ -1101,6 +1103,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1238,7 +1249,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1391,6 +1402,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]

--- a/configure
+++ b/configure
@@ -748,7 +748,6 @@ infodir
 docdir
 oldincludedir
 includedir
-runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -850,7 +849,6 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
-runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE}'
@@ -1103,15 +1101,6 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
-  -runstatedir | --runstatedir | --runstatedi | --runstated \
-  | --runstate | --runstat | --runsta | --runst | --runs \
-  | --run | --ru | --r)
-    ac_prev=runstatedir ;;
-  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
-  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
-  | --run=* | --ru=* | --r=*)
-    runstatedir=$ac_optarg ;;
-
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1249,7 +1238,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir runstatedir
+		libdir localedir mandir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1402,7 +1391,6 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
-  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -7724,8 +7712,8 @@ else
     _gs_cv_gcc_minor_version=""
     _gs_cv_gcc_parsed_version="no: it's not gcc"
     if test x"${GCC}" = x"yes" ; then
-                                                                                                      _gs_cv_gcc_major_version=`(${CC} -dumpversion | sed "s/\([^0-9]*\)\([0-9][0-9]*\)\([^0-9]*\)\([0-9][0-9]*\)\([^0-9]*.*\)/\2/") 2>&5`;
-      _gs_cv_gcc_minor_version=`(${CC} -dumpversion | sed "s/\([^0-9]*\)\([0-9][0-9]*\)\([^0-9]*\)\([0-9][0-9]*\)\([^0-9]*.*\)/\4/") 2>&5`;
+                                                                                                      _gs_cv_gcc_major_version=`(${CC} -dumpfullversion -dumpversion | sed "s/\([^0-9]*\)\([0-9][0-9]*\)\([^0-9]*\)\([0-9][0-9]*\)\([^0-9]*.*\)/\2/") 2>&5`;
+      _gs_cv_gcc_minor_version=`(${CC} -dumpfullversion -dumpversion | sed "s/\([^0-9]*\)\([0-9][0-9]*\)\([^0-9]*\)\([0-9][0-9]*\)\([^0-9]*.*\)/\4/") 2>&5`;
       _gs_cv_gcc_parsed_version="${_gs_cv_gcc_major_version}.${_gs_cv_gcc_minor_version}";
     fi
 

--- a/m4/gs_gcc_version.m4
+++ b/m4/gs_gcc_version.m4
@@ -39,8 +39,8 @@ AC_DEFUN([GS_CHECK_GCC_VERSION],dnl
       dnl All square brackets are doubled because this file is processed by m4 first.
       dnl Finally, any error messages are redirected to &5, so that they are logged
       dnl into config.log but don't clutter the normal user output.
-      _gs_cv_gcc_major_version=`(${CC} -dumpversion | sed "s/\([[^0-9]]*\)\([[0-9]][[0-9]]*\)\([[^0-9]]*\)\([[0-9]][[0-9]]*\)\([[^0-9]]*.*\)/\2/") 2>&5`;
-      _gs_cv_gcc_minor_version=`(${CC} -dumpversion | sed "s/\([[^0-9]]*\)\([[0-9]][[0-9]]*\)\([[^0-9]]*\)\([[0-9]][[0-9]]*\)\([[^0-9]]*.*\)/\4/") 2>&5`;
+      _gs_cv_gcc_major_version=`(${CC} -dumpfullversion -dumpversion | sed "s/\([[^0-9]]*\)\([[0-9]][[0-9]]*\)\([[^0-9]]*\)\([[0-9]][[0-9]]*\)\([[^0-9]]*.*\)/\2/") 2>&5`;
+      _gs_cv_gcc_minor_version=`(${CC} -dumpfullversion -dumpversion | sed "s/\([[^0-9]]*\)\([[0-9]][[0-9]]*\)\([[^0-9]]*\)\([[0-9]][[0-9]]*\)\([[^0-9]]*.*\)/\4/") 2>&5`;
       _gs_cv_gcc_parsed_version="${_gs_cv_gcc_major_version}.${_gs_cv_gcc_minor_version}";
     fi
   ])


### PR DESCRIPTION
extraction. Versions of gcc > 7.0 require this parameter to output
the full version number. Older versions should just ignore this option.
* configure: Regenerate. This remove the runstatedir option as my version
of autoconfig does not include it.