### PR TITLE
Support for storyboards in GNUmakefiles.

### DIFF
--- a/Instance/application.make
+++ b/Instance/application.make
@@ -223,10 +223,12 @@ MAIN_MODEL_FILE = $(strip $(subst .gmodel,,$(subst .gorm,,$(subst .nib,,$($(GNUS
 
 MAIN_MARKUP_FILE = $(strip $(subst .gsmarkup,,$($(GNUSTEP_INSTANCE)_MAIN_MARKUP_FILE)))
 
+MAIN_STORYBOARD_FILE = $(strip $(subst .gmodel,,$(subst .gorm,,$(subst .nib,,$($(GNUSTEP_INSTANCE)_MAIN_STORYBOARD_FILE)))))
+
 # We must recreate Info.plist if PRINCIPAL_CLASS and/or
-# APPLICATION_ICON and/or MAIN_MODEL_FILE and/or MAIN_MARKUP_FILE has
-# changed since last time we built Info.plist.  We use
-# stamp-string.make, which will store the variables in a stamp file
+# APPLICATION_ICON and/or MAIN_MODEL_FILE and/or MAIN_MARKUP_FILE and/or
+# MAIN_STORBOARD_FILE has changed since last time we built Info.plist.
+# We use stamp-string.make, which will store the variables in a stamp file
 # inside GNUSTEP_STAMP_DIR, and rebuild Info.plist if
 # GNUSTEP_STAMP_STRING changes.  We will also depend on xxxInfo.plist
 # if any.
@@ -265,6 +267,7 @@ $(APP_INFO_PLIST_FILE): $(GNUSTEP_STAMP_DEPEND) $(GNUSTEP_PLIST_DEPEND)
 	$(ECHO_CREATING)(echo "{"; echo '  NOTE = "Automatically generated, do not edit!";'; \
 	  echo "  NSExecutable = \"$(GNUSTEP_INSTANCE)\";"; \
 	  echo "  NSMainNibFile = \"$(MAIN_MODEL_FILE)\";"; \
+	  echo "  NSMainStoryboardFile = \"$(MAIN_STORYBOARD_FILE)\";"; \
 	  echo "  GSMainMarkupFile = \"$(MAIN_MARKUP_FILE)\";"; \
 	  if [ "$(APPLICATION_ICON)" != "" ]; then \
 	    echo "  CFBundleIconFile = \"$(APPLICATION_ICON)\";"; \
@@ -281,6 +284,7 @@ $(APP_INFO_PLIST_FILE): $(GNUSTEP_STAMP_DEPEND) $(GNUSTEP_PLIST_DEPEND)
 	$(ECHO_CREATING)(echo "{"; echo '  NOTE = "Automatically generated, do not edit!";'; \
 	  echo "  NSExecutable = \"$(GNUSTEP_INSTANCE)\";"; \
 	  echo "  NSMainNibFile = \"$(MAIN_MODEL_FILE)\";"; \
+	  echo "  NSMainStoryboardFile = \"$(MAIN_STORYBOARD_FILE)\";"; \
 	  echo "  GSMainMarkupFile = \"$(MAIN_MARKUP_FILE)\";"; \
 	  if [ "$(APPLICATION_ICON)" != "" ]; then \
 	    echo "  NSIcon = \"$(APPLICATION_ICON)\";"; \

--- a/Instance/application.make
+++ b/Instance/application.make
@@ -223,11 +223,11 @@ MAIN_MODEL_FILE = $(strip $(subst .gmodel,,$(subst .gorm,,$(subst .nib,,$($(GNUS
 
 MAIN_MARKUP_FILE = $(strip $(subst .gsmarkup,,$($(GNUSTEP_INSTANCE)_MAIN_MARKUP_FILE)))
 
-MAIN_STORYBOARD_FILE = $(strip $(subst .gmodel,,$(subst .gorm,,$(subst .nib,,$($(GNUSTEP_INSTANCE)_MAIN_STORYBOARD_FILE)))))
+MAIN_STORYBOARD_FILE = $(strip $(subst .storyboard,,$($(GNUSTEP_INSTANCE)_MAIN_STORYBOARD_FILE)))
 
 # We must recreate Info.plist if PRINCIPAL_CLASS and/or
 # APPLICATION_ICON and/or MAIN_MODEL_FILE and/or MAIN_MARKUP_FILE and/or
-# MAIN_STORBOARD_FILE has changed since last time we built Info.plist.
+# MAIN_STORYBOARD_FILE has changed since last time we built Info.plist.
 # We use stamp-string.make, which will store the variables in a stamp file
 # inside GNUSTEP_STAMP_DIR, and rebuild Info.plist if
 # GNUSTEP_STAMP_STRING changes.  We will also depend on xxxInfo.plist


### PR DESCRIPTION
Support for storyboards in GNUmakefiles.   This change simply adds the change to generate the entry in the Info.plist for loading a storyboard when one is specified.