### PR TITLE
Enable native Objective-C exception check on Windows

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2020-11-26  Frederik Seiffert <frederik@algoriddim.com>
+
+	* configure
+	* configure.ac:
+	Enable checking for native Objective-C exception support on Windows
+	if non-gnu runtime is used (i.e. ng runtime).
+
 2020-11-14  Richard Frith-Macdonald <rfm@gnu.org>
 
 	* rules.make:

--- a/configure
+++ b/configure
@@ -8144,7 +8144,7 @@ fi
 
 
 if test x"$USE_OBJC_EXCEPTIONS" = x"maybe"; then
-  if test x"$MSWIND" = x"yes"; then
+  if test x"$MSWIND" = x"yes" -a "$OBJC_RUNTIME_LIB" = "gnu"; then
     USE_OBJC_EXCEPTIONS=no
   fi
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -1386,7 +1386,7 @@ USE_OBJC_EXCEPTIONS=$enableval,
 USE_OBJC_EXCEPTIONS=maybe)
 
 if test x"$USE_OBJC_EXCEPTIONS" = x"maybe"; then
-  if test x"$MSWIND" = x"yes"; then
+  if test x"$MSWIND" = x"yes" -a "$OBJC_RUNTIME_LIB" = "gnu"; then
     USE_OBJC_EXCEPTIONS=no
   fi
 fi


### PR DESCRIPTION
Configure currently always forcefully disables support for native exceptions on Windows, even though they should be supported when using Clang and the ng runtime.

With this change, the check is only forcefully disabled when using the gnu runtime.