### PR TITLE
Check for objc.dll to support libobjc2 on Windows.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,12 @@
 
 	* configure
 	* configure.ac:
+	Check for objc.dll to support libobjc2 on Windows.
+
+2020-11-26  Frederik Seiffert <frederik@algoriddim.com>
+
+	* configure
+	* configure.ac:
 	Enable checking for native Objective-C exception support on Windows
 	if non-gnu runtime is used (i.e. ng runtime).
 

--- a/configure
+++ b/configure
@@ -6580,8 +6580,8 @@ if test "$OBJC_RUNTIME_LIB" = "gnu" -a x"$gs_cv_cc_is_clang" = x"yes" -a  x"$gs_
 
 
 
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for domains containing libraries libobjc.a, libobjc.so, libobjc.dll.a, libobjc-gnu.dylib" >&5
-$as_echo_n "checking for domains containing libraries libobjc.a, libobjc.so, libobjc.dll.a, libobjc-gnu.dylib... " >&6; }
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for domains containing libraries libobjc.a, libobjc.so, libobjc.dll.a, libobjc-gnu.dylib, objc.dll" >&5
+$as_echo_n "checking for domains containing libraries libobjc.a, libobjc.so, libobjc.dll.a, libobjc-gnu.dylib, objc.dll... " >&6; }
 if ${gs_cv_ng_libobjc_domains_ng_gnu_gnu+:} false; then :
   $as_echo_n "(cached) " >&6
 else
@@ -6613,7 +6613,7 @@ fi
     { _LIBRARY_COMBO=; unset _LIBRARY_COMBO;}
 
         if test -d  $gs_cv_SYSTEM_LIBRARIES_dir_ng_gnu_gnu; then
-            if test -f "$gs_cv_SYSTEM_LIBRARIES_dir_ng_gnu_gnu/libobjc.a" -o -f "$gs_cv_SYSTEM_LIBRARIES_dir_ng_gnu_gnu/libobjc.so" -o -f "$gs_cv_SYSTEM_LIBRARIES_dir_ng_gnu_gnu/libobjc.dll.a" -o -f "$gs_cv_SYSTEM_LIBRARIES_dir_ng_gnu_gnu/libobjc-gnu.dylib" ; then
+            if test -f "$gs_cv_SYSTEM_LIBRARIES_dir_ng_gnu_gnu/libobjc.a" -o -f "$gs_cv_SYSTEM_LIBRARIES_dir_ng_gnu_gnu/libobjc.so" -o -f "$gs_cv_SYSTEM_LIBRARIES_dir_ng_gnu_gnu/libobjc.dll.a" -o -f "$gs_cv_SYSTEM_LIBRARIES_dir_ng_gnu_gnu/libobjc-gnu.dylib" -o -f "$gs_cv_SYSTEM_LIBRARIES_dir_ng_gnu_gnu/objc.dll" ; then
                 gs_cv_ng_libobjc_domains_ng_gnu_gnu="${gs_cv_ng_libobjc_domains_ng_gnu_gnu}${INFIX}SYSTEM"
                 INFIX=", "
             fi
@@ -6644,7 +6644,7 @@ fi
     { _LIBRARY_COMBO=; unset _LIBRARY_COMBO;}
 
         if test -d  $gs_cv_NETWORK_LIBRARIES_dir_ng_gnu_gnu; then
-            if test -f "$gs_cv_NETWORK_LIBRARIES_dir_ng_gnu_gnu/libobjc.a" -o -f "$gs_cv_NETWORK_LIBRARIES_dir_ng_gnu_gnu/libobjc.so" -o -f "$gs_cv_NETWORK_LIBRARIES_dir_ng_gnu_gnu/libobjc.dll.a" -o -f "$gs_cv_NETWORK_LIBRARIES_dir_ng_gnu_gnu/libobjc-gnu.dylib" ; then
+            if test -f "$gs_cv_NETWORK_LIBRARIES_dir_ng_gnu_gnu/libobjc.a" -o -f "$gs_cv_NETWORK_LIBRARIES_dir_ng_gnu_gnu/libobjc.so" -o -f "$gs_cv_NETWORK_LIBRARIES_dir_ng_gnu_gnu/libobjc.dll.a" -o -f "$gs_cv_NETWORK_LIBRARIES_dir_ng_gnu_gnu/libobjc-gnu.dylib" -o -f "$gs_cv_NETWORK_LIBRARIES_dir_ng_gnu_gnu/objc.dll" ; then
                 gs_cv_ng_libobjc_domains_ng_gnu_gnu="${gs_cv_ng_libobjc_domains_ng_gnu_gnu}${INFIX}NETWORK"
                 INFIX=", "
             fi
@@ -6675,7 +6675,7 @@ fi
     { _LIBRARY_COMBO=; unset _LIBRARY_COMBO;}
 
         if test -d  $gs_cv_LOCAL_LIBRARIES_dir_ng_gnu_gnu; then
-            if test -f "$gs_cv_LOCAL_LIBRARIES_dir_ng_gnu_gnu/libobjc.a" -o -f "$gs_cv_LOCAL_LIBRARIES_dir_ng_gnu_gnu/libobjc.so" -o -f "$gs_cv_LOCAL_LIBRARIES_dir_ng_gnu_gnu/libobjc.dll.a" -o -f "$gs_cv_LOCAL_LIBRARIES_dir_ng_gnu_gnu/libobjc-gnu.dylib" ; then
+            if test -f "$gs_cv_LOCAL_LIBRARIES_dir_ng_gnu_gnu/libobjc.a" -o -f "$gs_cv_LOCAL_LIBRARIES_dir_ng_gnu_gnu/libobjc.so" -o -f "$gs_cv_LOCAL_LIBRARIES_dir_ng_gnu_gnu/libobjc.dll.a" -o -f "$gs_cv_LOCAL_LIBRARIES_dir_ng_gnu_gnu/libobjc-gnu.dylib" -o -f "$gs_cv_LOCAL_LIBRARIES_dir_ng_gnu_gnu/objc.dll" ; then
                 gs_cv_ng_libobjc_domains_ng_gnu_gnu="${gs_cv_ng_libobjc_domains_ng_gnu_gnu}${INFIX}LOCAL"
                 INFIX=", "
             fi
@@ -6706,7 +6706,7 @@ fi
     { _LIBRARY_COMBO=; unset _LIBRARY_COMBO;}
 
         if test -d  $gs_cv_USER_LIBRARIES_dir_ng_gnu_gnu; then
-            if test -f "$gs_cv_USER_LIBRARIES_dir_ng_gnu_gnu/libobjc.a" -o -f "$gs_cv_USER_LIBRARIES_dir_ng_gnu_gnu/libobjc.so" -o -f "$gs_cv_USER_LIBRARIES_dir_ng_gnu_gnu/libobjc.dll.a" -o -f "$gs_cv_USER_LIBRARIES_dir_ng_gnu_gnu/libobjc-gnu.dylib" ; then
+            if test -f "$gs_cv_USER_LIBRARIES_dir_ng_gnu_gnu/libobjc.a" -o -f "$gs_cv_USER_LIBRARIES_dir_ng_gnu_gnu/libobjc.so" -o -f "$gs_cv_USER_LIBRARIES_dir_ng_gnu_gnu/libobjc.dll.a" -o -f "$gs_cv_USER_LIBRARIES_dir_ng_gnu_gnu/libobjc-gnu.dylib" -o -f "$gs_cv_USER_LIBRARIES_dir_ng_gnu_gnu/objc.dll" ; then
                 gs_cv_ng_libobjc_domains_ng_gnu_gnu="${gs_cv_ng_libobjc_domains_ng_gnu_gnu}${INFIX}USER"
                 INFIX=", "
             fi
@@ -7083,8 +7083,8 @@ fi
 
 
 
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for domains containing libraries libobjc.a, libobjc.so, libobjc.dll.a, libobjc-gnu.dylib" >&5
-$as_echo_n "checking for domains containing libraries libobjc.a, libobjc.so, libobjc.dll.a, libobjc-gnu.dylib... " >&6; }
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for domains containing libraries libobjc.a, libobjc.so, libobjc.dll.a, libobjc-gnu.dylib, objc.dll" >&5
+$as_echo_n "checking for domains containing libraries libobjc.a, libobjc.so, libobjc.dll.a, libobjc-gnu.dylib, objc.dll... " >&6; }
 if ${gs_cv_dflt_libobjc_domains+:} false; then :
   $as_echo_n "(cached) " >&6
 else
@@ -7116,7 +7116,7 @@ fi
     { _LIBRARY_COMBO=; unset _LIBRARY_COMBO;}
 
         if test -d  $gs_cv_SYSTEM_LIBRARIES_dir; then
-            if test -f "$gs_cv_SYSTEM_LIBRARIES_dir/libobjc.a" -o -f "$gs_cv_SYSTEM_LIBRARIES_dir/libobjc.so" -o -f "$gs_cv_SYSTEM_LIBRARIES_dir/libobjc.dll.a" -o -f "$gs_cv_SYSTEM_LIBRARIES_dir/libobjc-gnu.dylib" ; then
+            if test -f "$gs_cv_SYSTEM_LIBRARIES_dir/libobjc.a" -o -f "$gs_cv_SYSTEM_LIBRARIES_dir/libobjc.so" -o -f "$gs_cv_SYSTEM_LIBRARIES_dir/libobjc.dll.a" -o -f "$gs_cv_SYSTEM_LIBRARIES_dir/libobjc-gnu.dylib" -o -f "$gs_cv_SYSTEM_LIBRARIES_dir/objc.dll" ; then
                 gs_cv_dflt_libobjc_domains="${gs_cv_dflt_libobjc_domains}${INFIX}SYSTEM"
                 INFIX=", "
             fi
@@ -7147,7 +7147,7 @@ fi
     { _LIBRARY_COMBO=; unset _LIBRARY_COMBO;}
 
         if test -d  $gs_cv_NETWORK_LIBRARIES_dir; then
-            if test -f "$gs_cv_NETWORK_LIBRARIES_dir/libobjc.a" -o -f "$gs_cv_NETWORK_LIBRARIES_dir/libobjc.so" -o -f "$gs_cv_NETWORK_LIBRARIES_dir/libobjc.dll.a" -o -f "$gs_cv_NETWORK_LIBRARIES_dir/libobjc-gnu.dylib" ; then
+            if test -f "$gs_cv_NETWORK_LIBRARIES_dir/libobjc.a" -o -f "$gs_cv_NETWORK_LIBRARIES_dir/libobjc.so" -o -f "$gs_cv_NETWORK_LIBRARIES_dir/libobjc.dll.a" -o -f "$gs_cv_NETWORK_LIBRARIES_dir/libobjc-gnu.dylib" -o -f "$gs_cv_NETWORK_LIBRARIES_dir/objc.dll" ; then
                 gs_cv_dflt_libobjc_domains="${gs_cv_dflt_libobjc_domains}${INFIX}NETWORK"
                 INFIX=", "
             fi
@@ -7178,7 +7178,7 @@ fi
     { _LIBRARY_COMBO=; unset _LIBRARY_COMBO;}
 
         if test -d  $gs_cv_LOCAL_LIBRARIES_dir; then
-            if test -f "$gs_cv_LOCAL_LIBRARIES_dir/libobjc.a" -o -f "$gs_cv_LOCAL_LIBRARIES_dir/libobjc.so" -o -f "$gs_cv_LOCAL_LIBRARIES_dir/libobjc.dll.a" -o -f "$gs_cv_LOCAL_LIBRARIES_dir/libobjc-gnu.dylib" ; then
+            if test -f "$gs_cv_LOCAL_LIBRARIES_dir/libobjc.a" -o -f "$gs_cv_LOCAL_LIBRARIES_dir/libobjc.so" -o -f "$gs_cv_LOCAL_LIBRARIES_dir/libobjc.dll.a" -o -f "$gs_cv_LOCAL_LIBRARIES_dir/libobjc-gnu.dylib" -o -f "$gs_cv_LOCAL_LIBRARIES_dir/objc.dll" ; then
                 gs_cv_dflt_libobjc_domains="${gs_cv_dflt_libobjc_domains}${INFIX}LOCAL"
                 INFIX=", "
             fi
@@ -7209,7 +7209,7 @@ fi
     { _LIBRARY_COMBO=; unset _LIBRARY_COMBO;}
 
         if test -d  $gs_cv_USER_LIBRARIES_dir; then
-            if test -f "$gs_cv_USER_LIBRARIES_dir/libobjc.a" -o -f "$gs_cv_USER_LIBRARIES_dir/libobjc.so" -o -f "$gs_cv_USER_LIBRARIES_dir/libobjc.dll.a" -o -f "$gs_cv_USER_LIBRARIES_dir/libobjc-gnu.dylib" ; then
+            if test -f "$gs_cv_USER_LIBRARIES_dir/libobjc.a" -o -f "$gs_cv_USER_LIBRARIES_dir/libobjc.so" -o -f "$gs_cv_USER_LIBRARIES_dir/libobjc.dll.a" -o -f "$gs_cv_USER_LIBRARIES_dir/libobjc-gnu.dylib" -o -f "$gs_cv_USER_LIBRARIES_dir/objc.dll" ; then
                 gs_cv_dflt_libobjc_domains="${gs_cv_dflt_libobjc_domains}${INFIX}USER"
                 INFIX=", "
             fi

--- a/m4/gs_objc_runtime.m4
+++ b/m4/gs_objc_runtime.m4
@@ -90,7 +90,7 @@ AC_DEFUN([GS_CUSTOM_OBJC_RUNTIME_DOMAIN], [
     m4_pushdef([LIBOBJC_DOMAINS], m4_join([_], LIBOBJC, [DOMAINS]))
     m4_pushdef([OBJC_HEADERS_DOMAINS], m4_join([_], OBJC_HEADERS, [DOMAINS]))
     m4_pushdef([gs_cv_libobjc_domain], m4_join([_], [gs_cv_libobjc_domain], m4_tolower($1)))
-    GS_DOMAINS_FOR_FILES([LIBOBJC], [LIBRARIES], [libobjc.a, libobjc.so, libobjc.dll.a, libobjc-gnu.dylib], [$2])
+    GS_DOMAINS_FOR_FILES([LIBOBJC], [LIBRARIES], [libobjc.a, libobjc.so, libobjc.dll.a, libobjc-gnu.dylib, objc.dll], [$2])
     GS_DOMAINS_FOR_FILES([OBJC_HEADERS], [HEADERS], [objc/objc.h], [$2])
     AC_CACHE_CHECK([for custom shared objc library domain], [gs_cv_libobjc_domain], [
         gs_cv_libobjc_domain=""


### PR DESCRIPTION
This is the library file name used by libobjc2 on Windows. Fixes having to manually specify library and header search paths.