### PR TITLE
Support building on Windows with Clang MSVC target

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,16 @@
+2021-01-29  Frederik Seiffert <frederik@algoriddim.com>
+
+	* Instance/rules.make:
+	* Instance/subproject.make:
+	* common.make:
+	Link subproject object files directly. Instead of merging all
+	subproject object files into subproject.o, we now create
+	subproject.txt containing a list of all object files, and use these
+	directly in SUBPROJECT_OBJ_FILES.
+	This enables building on platforms like Windows MSVC where `ld -r` is
+	not supported, and generally avoids issues with incremental linking
+	that have historically existed in some linker versions.
+
 2021-01-18  Fred Kiefer <FredKiefer@gmx.de>
 
 	* Documentation/news.texi: Update for upcoming release.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,17 @@
 2021-01-29  Frederik Seiffert <frederik@algoriddim.com>
 
 	* common.make:
+	* configure:
+	* m4/gs_cc_is_clang.m4:
+	* target.make:
+	Added support for building on Windows with Clang MSVC target.
+	Requires passing a host like --host=x86_64-pc-windows.
+	Removes the check for $GCC in gs_cc_is_clang.m4 as it will be false
+	when using the MSVC ABI due to __GNUC__ not being defined.
+
+2021-01-29  Frederik Seiffert <frederik@algoriddim.com>
+
+	* common.make:
 	* target.make:
 	Check $CLANG_CC instead of comparing $CC with "clang". Fixes checks
 	when $CC is set to something like /path/to/clang.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,12 @@
 2021-01-29  Frederik Seiffert <frederik@algoriddim.com>
 
+	* common.make:
+	* target.make:
+	Check $CLANG_CC instead of comparing $CC with "clang". Fixes checks
+	when $CC is set to something like /path/to/clang.
+
+2021-01-29  Frederik Seiffert <frederik@algoriddim.com>
+
 	* Instance/rules.make:
 	* Instance/subproject.make:
 	* common.make:

--- a/Instance/rules.make
+++ b/Instance/rules.make
@@ -206,7 +206,9 @@ endif
 
 ifneq ($($(GNUSTEP_INSTANCE)_SUBPROJECTS),)
 SUBPROJECT_OBJ_FILES = $(foreach d, $($(GNUSTEP_INSTANCE)_SUBPROJECTS), \
-    $(addprefix $(GNUSTEP_BUILD_DIR)/$(d)/, $(GNUSTEP_OBJ_DIR_NAME)/$(SUBPROJECT_PRODUCT)))
+    $(foreach o, $(shell cat \
+    $(GNUSTEP_BUILD_DIR)/$(d)/$(GNUSTEP_OBJ_DIR_NAME)/$(SUBPROJECT_PRODUCT)), \
+    $(addprefix $(GNUSTEP_BUILD_DIR)/$(d)/, $(o))))
 endif
 
 OBJC_OBJS = $(patsubst %.m,%.m$(OEXT),$($(GNUSTEP_INSTANCE)_OBJC_FILES))

--- a/Instance/subproject.make
+++ b/Instance/subproject.make
@@ -58,7 +58,7 @@ $(GNUSTEP_OBJ_DIR)/$(SUBPROJECT_PRODUCT): $(OBJ_FILES_TO_LINK)
 ifeq ($(OBJ_FILES_TO_LINK),)
 	$(WARNING_EMPTY_LINKING)
 endif
-	$(ECHO_LINKING)$(OBJ_MERGE_CMD)$(END_ECHO)
+	@echo "$(OBJ_FILES_TO_LINK)" > $(GNUSTEP_OBJ_DIR)/$(SUBPROJECT_PRODUCT)
 
 #
 # Build-header target for framework subprojects

--- a/common.make
+++ b/common.make
@@ -638,7 +638,7 @@ INTERNAL_OBJCFLAGS = -fno-strict-aliasing
 # Linux CentOS 6.5 i386 clang...
 # Clang inserts move aligned packed instructions (i.e. movaps,etc) assembly
 # code however stack is not aligned causing fault crashes...
-ifeq ($(CC),clang)
+ifeq ($(CLANG_CC), yes)
 ifneq ($(wildcard /etc/redhat-release),"")
 RH_RELEASE := $(shell cat 2>/dev/null /etc/redhat-release)
 ifeq ($(findstring CentOS,$(RH_RELEASE)),CentOS)

--- a/common.make
+++ b/common.make
@@ -815,7 +815,7 @@ endif
 #
 # Common variables for subprojects
 #
-SUBPROJECT_PRODUCT = subproject$(OEXT)
+SUBPROJECT_PRODUCT = subproject.txt
 
 #
 # Set JAVA_HOME if not set.

--- a/configure
+++ b/configure
@@ -4474,10 +4474,8 @@ if ${_gs_cv_cc_is_clang+:} false; then :
   $as_echo_n "(cached) " >&6
 else
       _gs_cv_cc_is_clang="no"
-    if test x"${GCC}" = x"yes" ; then
-        if "${CC}" -v 2>&1 | grep -q 'clang version'; then
-            _gs_cv_cc_is_clang="yes";
-        fi
+    if "${CC}" -v 2>&1 | grep -q 'clang version'; then
+        _gs_cv_cc_is_clang="yes";
     fi
 
 fi

--- a/m4/gs_cc_is_clang.m4
+++ b/m4/gs_cc_is_clang.m4
@@ -14,10 +14,8 @@ AC_DEFUN([GS_CHECK_CC_IS_CLANG],dnl
   [AC_REQUIRE([AC_PROG_CC])
     AC_CACHE_CHECK([whether the compiler is clang],[_gs_cv_cc_is_clang], [dnl
     _gs_cv_cc_is_clang="no"
-    if test x"${GCC}" = x"yes" ; then
-        if "${CC}" -v 2>&1 | grep -q 'clang version'; then
-            _gs_cv_cc_is_clang="yes";
-        fi
+    if "${CC}" -v 2>&1 | grep -q 'clang version'; then
+        _gs_cv_cc_is_clang="yes";
     fi
     ])
     AS_VAR_SET([gs_cv_cc_is_clang], [${_gs_cv_cc_is_clang}])

--- a/target.make
+++ b/target.make
@@ -845,7 +845,7 @@ SHARED_LIBEXT    = .dll.a
 DLL_LIBEXT	 = .dll
 #SHARED_CFLAGS	 += 
 
-ifneq ($(CC),clang)
+ifneq ($(CLANG_CC), yes)
 OBJ_MERGE_CMD = \
   $(LD) -nostdlib $(OBJ_MERGE_CMD_FLAG) $(CORE_LDFLAGS) -o $(GNUSTEP_OBJ_DIR)/$(SUBPROJECT_PRODUCT) $^ ;
 else
@@ -856,7 +856,7 @@ endif
 HAVE_BUNDLES   = yes
 BUNDLE_LD      = $(LD)
 
-ifeq ($(CC),clang)
+ifeq ($(CLANG_CC), yes)
 BUNDLE_LDFLAGS += -shared -Wl,--export-all-symbols \
 	-Wl,--enable-auto-import \
         -Wl,--enable-auto-image-base \
@@ -907,7 +907,7 @@ SHARED_CFLAGS =
 # while it is the default, it might silently get disabled if a symbol
 # gets manually exported (eg, because a header of a library we include
 # exports a symbol by mistake).
-ifneq ($(CC),clang)
+ifneq ($(CLANG_CC), yes)
 SHARED_LIB_LINK_CMD     = \
         $(LD) $(SHARED_LD_PREFLAGS) -shared \
         -Wl,--enable-auto-image-base \
@@ -944,7 +944,7 @@ SHARED_LIBEXT    = .dll.a
 DLL_LIBEXT	 = .dll
 #SHARED_CFLAGS	 += 
 
-ifneq ($(CC),clang)
+ifneq ($(CLANG_CC), yes)
 OBJ_MERGE_CMD = \
   $(LD) -nostdlib $(OBJ_MERGE_CMD_FLAG) $(CORE_LDFLAGS) -o $(GNUSTEP_OBJ_DIR)/$(SUBPROJECT_PRODUCT) $^ ;
 else
@@ -955,7 +955,7 @@ endif
 HAVE_BUNDLES   = yes
 BUNDLE_LD      = $(LD)
 
-ifeq ($(CC),clang)
+ifeq ($(CLANG_CC), yes)
 BUNDLE_LDFLAGS += -shared -Wl,--export-all-symbols \
 	-Wl,--enable-auto-import \
         -Wl,--enable-auto-image-base \


### PR DESCRIPTION
These changes enable building on Windows with Clang, libobjc2, and the MSVC ABI (i.e. not using MinGW).

Requires using a standard Windows Clang build that e.g. comes with Visual Studio or is available as pre-built binary from the [LLVM website](https://releases.llvm.org/download.html). Invoking `clang -v` should show a target like `x86_64-pc-windows-msvc`.

Configure must be invoked with a host like `x86_64-pc-windows` or `i386-pc-windows`, e.g.:
```
export CC=/C/LLVM/bin/clang
export CXX=/C/LLVM/bin/clang++
export OBJCXX=/C/LLVM/bin/clang++

./configure --host=x86_64-pc-windows --with-library-combo=ng-gnu-gnu --with-runtime-abi=gnustep-2.0 --prefix=/c/GNUstep/x64 LDFLAGS="-fuse-ld=lld"
```

As the Windows linker does not support incremental linking using `ld -r`, this also contains a change to link subproject object files directly (https://github.com/gnustep/tools-make/commit/434f957df0ad81b52a09e3f8c4a200734898b342): Instead of merging all subproject object files into `subproject.o`, we now create a `subproject.txt` containing a list of all object files, and use these directly in `SUBPROJECT_OBJ_FILES`. This affects all platforms and seems to work fine in CI for all existing targets, but please let me know if there are any concerns with this change.

Accompanying pull request for Base forthcoming.