### PR TITLE
Windows MSVC fixes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,9 @@
 	* target.make:
 	Link against debug or release UCRT DLLs for Windows MSVC and remove
 	unused -pthread flag.
+	* configure:
+	* configure.ac:
+	Fix CFLAGS for Windows MSVC.
 
 2021-02-12  Frederik Seiffert <frederik@algoriddim.com>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2021-03-09  Frederik Seiffert <frederik@algoriddim.com>
+
+	* target.make:
+	Link against debug or release UCRT DLLs for Windows MSVC and remove
+	unused -pthread flag.
+
 2021-02-12  Frederik Seiffert <frederik@algoriddim.com>
 
 	* common.make: Silence PATH warning on Windows MSVC.

--- a/TestFramework/Testing.h
+++ b/TestFramework/Testing.h
@@ -26,7 +26,7 @@
 #include <string.h>
 
 #import <Foundation/NSAutoreleasePool.h>
-#import <Foundation/NSDate.h>
+#import <Foundation/NSCalendarDate.h>
 #import <Foundation/NSException.h>
 #import <Foundation/NSObjCRuntime.h>
 #import <Foundation/NSObject.h>

--- a/configure
+++ b/configure
@@ -4918,6 +4918,12 @@ fi
 
 fi
 
+# On Windows MSVC, AC_PROG_CC will not detect Clang in MSVC mode as a
+# GNU C compiler and therefore set CFLAGS to just "-g", so we fix it.
+if test "$target_os" = windows -a x"${GCC}" != x"yes" -a x"$gs_cv_cc_is_clang" = x"yes"; then
+  CFLAGS="-g -O2"
+fi
+
 # Find a good install program.  We prefer a C program (faster),
 # so one script is as good as another.  But avoid the broken or
 # incompatible versions:

--- a/configure.ac
+++ b/configure.ac
@@ -243,6 +243,12 @@ else
   AC_PROG_RANLIB
 fi
 
+# On Windows MSVC, AC_PROG_CC will not detect Clang in MSVC mode as a
+# GNU C compiler and therefore set CFLAGS to just "-g", so we fix it.
+if test "$target_os" = windows -a x"${GCC}" != x"yes" -a x"$gs_cv_cc_is_clang" = x"yes"; then
+  CFLAGS="-g -O2"
+fi
+
 AC_PROG_INSTALL
 
 AC_MSG_CHECKING([if 'install -p' works])

--- a/target.make
+++ b/target.make
@@ -42,10 +42,11 @@ endif
 # All code we build needs to be thread-safe nowadays
 INTERNAL_CFLAGS = -pthread
 INTERNAL_OBJCFLAGS = -pthread
-ifeq ($(findstring android, $(GNUSTEP_TARGET_OS)), android)
-  INTERNAL_LDFLAGS = 
-else
-  INTERNAL_LDFLAGS = -pthread
+INTERNAL_LDFLAGS =
+ifneq ($(findstring android, $(GNUSTEP_TARGET_OS)), android)
+	ifneq ($(GNUSTEP_TARGET_OS), windows)
+		INTERNAL_LDFLAGS = -pthread
+	endif
 endif
 
 ifneq ("$(objc_threaded)","")
@@ -63,6 +64,16 @@ else ifeq ($(GNUSTEP_TARGET_OS), windows)
   TARGET_SYSTEM_LIBS = $(CONFIG_SYSTEM_LIBS) \
 	-lws2_32 -ladvapi32 -lcomctl32 -luser32 -lcomdlg32 \
 	-lmpr -lnetapi32 -lkernel32 -lshell32
+	
+	# link against debug or release UCRT DLLs (i.e. /MDd or /MD)
+	ifeq ($(debug),)
+		debug = $(GNUSTEP_DEFAULT_DEBUG)
+	endif
+	ifeq ($(debug), yes)
+		TARGET_SYSTEM_LIBS += -lmsvcrtd -lvcruntimed -lucrtd
+	else
+		TARGET_SYSTEM_LIBS += -lmsvcrt -lvcruntime -lucrt
+	endif
 endif
 
 ifeq ($(findstring solaris, $(GNUSTEP_TARGET_OS)), solaris)


### PR DESCRIPTION
A couple of fixes for Windows MSVC:

- Link against debug or release UCRT DLLs depending on $debug
- Removed unused `-pthread` flag (caused compiler warning)
- Fix CFLAGS, as AC_PROG_CC will not detect Clang in MSVC mode as a GNU C compiler and therefore sets CFLAGS to just `-g`.
- Fixes incorrect import statement in Testing.h, which caused linker errors when running tests on Windows MSVC because the compiler needs to see the __dllspec on NSCalendarDate in order to be able to link against it.