### PR TITLE
Windows MSVC: suppress Clang warning -Wmicrosoft-include

### DIFF
--- a/target.make
+++ b/target.make
@@ -1009,6 +1009,10 @@ BUNDLE_LINK_CMD  = \
 # On Windows MSVC, class name symbols start with '__'
 EXTRACT_CLASS_NAMES_COMMAND = $(NM) -Pg $$object_file | sed -n -e '/^._OBJC_CLASS_[A-Za-z0-9_.]* [^U]/ {s/^._OBJC_CLASS_\([A-Za-z0-9_.]*\) [^U].*/\1/p;}' -e '/^__objc_class_name_[A-Za-z0-9_.]* [^U]/ {s/^__objc_class_name_\([A-Za-z0-9_.]*\) [^U].*/\1/p;}'
 
+# Suppress Clang warning in Base when including "GNUstepBase/GSConfig.h":
+# #include resolved using non-portable Microsoft search rules as: ././GNUstepBase/GSConfig.h
+ADDITIONAL_FLAGS += -Wno-microsoft-include
+
 endif
 
 # end Windows MSVC


### PR DESCRIPTION
Silences a bunch of warnings like the following when building for Windows MSVC, as can be seen in [recent CI runs](https://github.com/gnustep/libs-base/runs/3274204118?check_suite_focus=true). Please let me know if there’s a better place to put this.

```
In file included from GSLocale.m:25:
In file included from ././common.h:35:
../Headers\GNUstepBase/GSVersionMacros.h:222:10: warning: #include resolved using non-portable Microsoft search rules as: ././GNUstepBase/GSConfig.h [-Wmicrosoft-include]
#include "GNUstepBase/GSConfig.h"
         ^
```

Stack Overflow has [a bit more info](https://stackoverflow.com/a/48539191/1534401) on the warning. Silencing it seemed like the best way forward to me.