### PR TITLE
* Documentation is now installed in the LOCAL domain

### DIFF
--- a/Documentation/GNUmakefile
+++ b/Documentation/GNUmakefile
@@ -83,7 +83,7 @@ else
 # normal gnustep-make GNUmakefile for documentation.
 
 # We normally install into System
-GNUSTEP_INSTALLATION_DOMAIN = SYSTEM
+GNUSTEP_INSTALLATION_DOMAIN = LOCAL
 
 include $(GNUSTEP_MAKEFILES)/common.make
 


### PR DESCRIPTION
* Documentation/GNUmakefile:
  - all packages except for tools-make are installed
    to the LOCAL domain nowadays...
    it would be better to install the Documentation part
    of the tools-make there too because it contains
    articles/docs referenced from other libraries'
    Documentation parts
    (e.g. base' Documentation/HtmlNav/index.html)