### PR TITLE
Add missing LIB_LINK_PDB_FILE variable to framework.make

### DIFF
--- a/Instance/framework.make
+++ b/Instance/framework.make
@@ -299,6 +299,11 @@ SONAME_FRAMEWORK_FILE  = $(FRAMEWORK_LIBRARY_FILE)
 # as under Unix.
 LIB_LINK_DLL_FILE    = $(DLL_PREFIX)$(GNUSTEP_INSTANCE)-$(subst .,_,$(INTERFACE_VERSION))$(DLL_LIBEXT)
 
+# LIB_LINK_PDB_FILE is the PDB symbol file. The program database (PDB)
+# includes instructions for formatting trace messages so that they
+# can be presented in a human-readable display.
+LIB_LINK_PDB_FILE  = $(DLL_PREFIX)$(GNUSTEP_INSTANCE)-$(subst .,_,$(INTERFACE_VERSION))$(DLL_PDBEXT)
+
 FRAMEWORK_OBJ_EXT = $(DLL_LIBEXT)
 endif # BUILD_DLL
 


### PR DESCRIPTION
Windows uses a PDB file to store debug information. The path of this file is computed here: https://github.com/gnustep/tools-make/blob/00a4e989aee39b50852f7e49a67b19cc311dbbe8/target.make#L982 

LIB_LINK_PDB_FILE is not populated when building a framework on Windows MSVC. LIB_LINK_PDB_FILE is defined in library.make, but missing in framework.make: https://github.com/gnustep/tools-make/blob/00a4e989aee39b50852f7e49a67b19cc311dbbe8/Instance/library.make#L239.