### PR TITLE
Windows MSVC debug symbols, gnustep-tests extension, and typo fixes

### DIFF
--- a/TestFramework/gnustep-tests.in
+++ b/TestFramework/gnustep-tests.in
@@ -106,7 +106,7 @@ do
       echo "Use 'gnustep-tests --documentation' for full details."
       echo "Use 'gnustep-tests --clean' to remove old logs and leftover files."
       echo "Use 'gnustep-tests --failfast' to stop after the first failure."
-      echo "Use 'gnustep-tests --debug' to run gdb for any failed tests."
+      echo "Use 'gnustep-tests --debug' to run gdb/lldb for any failed tests."
       echo "Use 'gnustep-tests --make-debug' to enable make debug output."
       echo "Use 'gnustep-tests --make-no-silent' to disable silent make output."
       echo "Use 'gnustep-tests --developer' to treat hopes as real tests."

--- a/TestFramework/gnustep-tests.in
+++ b/TestFramework/gnustep-tests.in
@@ -50,6 +50,7 @@ export GSTESTDIR
 GSTESTMODE=normal
 
 GSMAKEOPTIONS="debug=yes"
+GSVERBOSECFLAG=
 
 # Argument checking
 while test $# != 0
@@ -91,6 +92,7 @@ do
     --verbose)
       GSVERBOSE=yes
       GSMAKEOPTIONS+=" messages=yes"
+      GSVERBOSECFLAG="-v"
       ;;
     --failfast)
       GSTESTMODE=failfast

--- a/TestFramework/gnustep-tests.in
+++ b/TestFramework/gnustep-tests.in
@@ -49,6 +49,8 @@ export GSTESTDIR
 
 GSTESTMODE=normal
 
+GSMAKEOPTIONS="debug=yes"
+
 # Argument checking
 while test $# != 0
 do
@@ -59,6 +61,12 @@ do
       ;;
     --debug)
       GSTESTDBG="$GSTESTDIR/gdb.cmds"
+      ;;
+    --make-debug)
+      GSMAKEOPTIONS+=" --debug"
+      ;;
+    --make-no-silent)
+      GSMAKEOPTIONS+=" --no-silent"
       ;;
     --developer)
       GSTESTDEV=yes
@@ -82,6 +90,7 @@ do
       ;;
     --verbose)
       GSVERBOSE=yes
+      GSMAKEOPTIONS+=" messages=yes"
       ;;
     --failfast)
       GSTESTMODE=failfast
@@ -96,6 +105,8 @@ do
       echo "Use 'gnustep-tests --clean' to remove old logs and leftover files."
       echo "Use 'gnustep-tests --failfast' to stop after the first failure."
       echo "Use 'gnustep-tests --debug' to run gdb for any failed tests."
+      echo "Use 'gnustep-tests --make-debug' to enable make debug output."
+      echo "Use 'gnustep-tests --make-no-silent' to disable silent make output."
       echo "Use 'gnustep-tests --developer' to treat hopes as real tests."
       echo "Use 'gnustep-tests --verbose' for full/detailed log output."
       echo "Use 'gnustep-tests --sequential' to disable parallel building."
@@ -350,23 +361,19 @@ build_test ()
         tmp=`basename $TESTFILE .c`
         if test x"$tmp" = x"$TESTFILE"
         then
-          BUILD_CMD="$CXX -o ./obj/$TESTNAME $TESTFILE $ADDITIONAL_CXXFLAGS $ADDITIONAL_LDFLAGS"
+          BUILD_CMD="$CXX -o $GSVERBOSECFLAG ./obj/$TESTNAME $TESTFILE $ADDITIONAL_CXXFLAGS $ADDITIONAL_LDFLAGS"
         else
-          BUILD_CMD="$CC -o ./obj/$TESTNAME $TESTFILE $ADDITIONAL_CFLAGS $ADDITIONAL_LDFLAGS"
+          BUILD_CMD="$CC -o $GSVERBOSECFLAG ./obj/$TESTNAME $TESTFILE $ADDITIONAL_CFLAGS $ADDITIONAL_LDFLAGS"
         fi
       else
-        BUILD_CMD="$OBJCXX -o ./obj/$TESTNAME $TESTFILE $GSTESTFLAGS $GSTESTLIBS"
+        BUILD_CMD="$OBJCXX -o $GSVERBOSECFLAG ./obj/$TESTNAME $TESTFILE $GSTESTFLAGS $GSTESTLIBS"
       fi
     else
-      BUILD_CMD="$CC -o ./obj/$TESTNAME $TESTFILE $GSTESTFLAGS $GSTESTLIBS"
+      BUILD_CMD="$CC -o $GSVERBOSECFLAG ./obj/$TESTNAME $TESTFILE $GSTESTFLAGS $GSTESTLIBS"
     fi
   else
-    if test x"$GSVERBOSE" = xyes
-    then
-      BUILD_CMD="$MAKE_CMD messages=yes debug=yes $TESTNAME"
-    else
-      BUILD_CMD="$MAKE_CMD debug=yes $TESTNAME"
-    fi
+    echo $GSMAKEOPTIONS
+    BUILD_CMD="$MAKE_CMD $GSMAKEOPTIONS $TESTNAME"
   fi
 
   # Redirect errors to stdout so it shows up in the log,
@@ -716,9 +723,9 @@ ${tmp}_OBJC_FILES=$TESTFILE"
             echo "Building in $dir" >>$GSTESTLOG
             if test -r ./make-check.env
             then
-              ( . ./make-check.env; . ./TestInfo > /dev/null 2>&1; $MAKE_CMD -j 4 debug=yes) >>$GSTESTLOG 2>&1
+              ( . ./make-check.env; . ./TestInfo > /dev/null 2>&1; $MAKE_CMD -j 4 $GSMAKEOPTIONS) >>$GSTESTLOG 2>&1
             else
-              ( . ./TestInfo > /dev/null 2>&1; $MAKE_CMD -j 4 debug=yes) >>$GSTESTLOG 2>&1
+              ( . ./TestInfo > /dev/null 2>&1; $MAKE_CMD -j 4 $GSMAKEOPTIONS) >>$GSTESTLOG 2>&1
             fi
             build_state=$?
           fi

--- a/common.make
+++ b/common.make
@@ -747,7 +747,6 @@ ifeq ($(debug), yes)
   ifneq ($(filter -g, $(OPTFLAG)), -g)
     ADDITIONAL_FLAGS += -g
   endif
-
   # Add standard debug compiler flags.
   ADDITIONAL_FLAGS += -DDEBUG -fno-omit-frame-pointer
 

--- a/common.make
+++ b/common.make
@@ -747,6 +747,12 @@ ifeq ($(debug), yes)
   ifneq ($(filter -g, $(OPTFLAG)), -g)
     ADDITIONAL_FLAGS += -g
   endif
+
+  # Embed PDB Debug Info on Windows MSVC
+  ifeq (@target_os@,windows)
+    LDFLAGS += -debug
+  endif
+
   # Add standard debug compiler flags.
   ADDITIONAL_FLAGS += -DDEBUG -fno-omit-frame-pointer
 

--- a/common.make
+++ b/common.make
@@ -749,8 +749,8 @@ ifeq ($(debug), yes)
   endif
 
   # Embed PDB Debug Info on Windows MSVC
-  ifeq (@target_os@,windows)
-    LDFLAGS += -debug
+  ifeq ($GNUSTEP_TARGET_OS,windows)
+    LDFLAGS += -Wl,-debug
   endif
 
   # Add standard debug compiler flags.

--- a/common.make
+++ b/common.make
@@ -748,11 +748,6 @@ ifeq ($(debug), yes)
     ADDITIONAL_FLAGS += -g
   endif
 
-  # Embed PDB Debug Info on Windows MSVC
-  ifeq ($GNUSTEP_TARGET_OS,windows)
-    LDFLAGS += -Wl,-debug
-  endif
-
   # Add standard debug compiler flags.
   ADDITIONAL_FLAGS += -DDEBUG -fno-omit-frame-pointer
 

--- a/m4/gs_check_abi20_linker.m4
+++ b/m4/gs_check_abi20_linker.m4
@@ -11,7 +11,7 @@ AC_DEFUN([GS_CHECK_ABI20_LINKER], [dnl
     AC_REQUIRE([AC_PROG_CC])
     AC_REQUIRE([AC_PROG_GREP])
     AC_CACHE_CHECK([for an gnustep-2.0 ABI compatible linker],[gs_cv_abi20_linker], [dnl
-        gs_cv_abi20_linker="unkown"
+        gs_cv_abi20_linker="unknown"
         AS_VAR_PUSHDEF([LD], [gs_cv_abi20_linker_prog])
         LD=$($CC --print-prog-name=ld)
         if $LD --version | $GREP -q 'GNU ld'; then

--- a/target.make
+++ b/target.make
@@ -43,6 +43,14 @@ endif
 INTERNAL_CFLAGS = -pthread
 INTERNAL_OBJCFLAGS = -pthread
 INTERNAL_LDFLAGS =
+  
+ifeq ($(debug), yes)
+  # Embed PDB Debug Info on Windows MSVC
+  ifeq ($(findstring windows, $(GNUSTEP_TARGET_OS)), windows)
+    INTERNAL_LDFLAGS += -Wl,-debug
+  endif
+endif
+
 ifneq ($(findstring android, $(GNUSTEP_TARGET_OS)), android)
 	ifneq ($(GNUSTEP_TARGET_OS), windows)
 		INTERNAL_LDFLAGS = -pthread


### PR DESCRIPTION
- gnustep-tests:
   - Add --make-debug flag to enable make internal debug output (Stored in test.log)
   - Add --make-no-silent to echo every make command (Stored in test.log)
   - Add -v invocation to CC when --verbose flag is set
- target.make:
   - Generate Windows MSVC PDB debug symbol files when debug is set to yes
- m4/gs_check_abi20_linker.m4:
   - Fix typo 