### PR TITLE
Rewrite linker detection (GS_CHECK_ABI20_LINKER)

### DIFF
--- a/configure
+++ b/configure
@@ -4878,11 +4878,11 @@ if test x$ac_prog_cxx_stdcxx = xno
 then :
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CXX option to enable C++11 features" >&5
 printf %s "checking for $CXX option to enable C++11 features... " >&6; }
-if test ${ac_cv_prog_cxx_11+y}
+if test ${ac_cv_prog_cxx_cxx11+y}
 then :
   printf %s "(cached) " >&6
 else $as_nop
-  ac_cv_prog_cxx_11=no
+  ac_cv_prog_cxx_cxx11=no
 ac_save_CXX=$CXX
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -4924,11 +4924,11 @@ if test x$ac_prog_cxx_stdcxx = xno
 then :
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CXX option to enable C++98 features" >&5
 printf %s "checking for $CXX option to enable C++98 features... " >&6; }
-if test ${ac_cv_prog_cxx_98+y}
+if test ${ac_cv_prog_cxx_cxx98+y}
 then :
   printf %s "(cached) " >&6
 else $as_nop
-  ac_cv_prog_cxx_98=no
+  ac_cv_prog_cxx_cxx98=no
 ac_save_CXX=$CXX
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -7522,12 +7522,12 @@ else
         _pkg_short_errors_supported=no
 fi
         if test $_pkg_short_errors_supported = yes; then
-	        libobjc_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libobjc >= 2" 2>&1`
+                libobjc_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libobjc >= 2" 2>&1`
         else
-	        libobjc_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libobjc >= 2" 2>&1`
+                libobjc_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libobjc >= 2" 2>&1`
         fi
-	# Put the nasty error message in config.log where it belongs
-	echo "$libobjc_PKG_ERRORS" >&5
+        # Put the nasty error message in config.log where it belongs
+        echo "$libobjc_PKG_ERRORS" >&5
 
 
             if test -n "$PKG_CONFIG" && \
@@ -7589,14 +7589,14 @@ else
         _pkg_short_errors_supported=no
 fi
         if test $_pkg_short_errors_supported = yes; then
-	        libobjc_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libobjc" 2>&1`
+                libobjc_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libobjc" 2>&1`
         else
-	        libobjc_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libobjc" 2>&1`
+                libobjc_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libobjc" 2>&1`
         fi
-	# Put the nasty error message in config.log where it belongs
-	echo "$libobjc_PKG_ERRORS" >&5
+        # Put the nasty error message in config.log where it belongs
+        echo "$libobjc_PKG_ERRORS" >&5
 
-	as_fn_error $? "Package requirements (libobjc) were not met:
+        as_fn_error $? "Package requirements (libobjc) were not met:
 
 $libobjc_PKG_ERRORS
 
@@ -7609,7 +7609,7 @@ See the pkg-config man page for more details." "$LINENO" 5
 elif test $pkg_failed = untried; then
         { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
 printf "%s\n" "no" >&6; }
-	{ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+        { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
 printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
 as_fn_error $? "The pkg-config script could not be found or is too old.  Make sure it
 is in your PATH or set the PKG_CONFIG environment variable to the full
@@ -7622,8 +7622,8 @@ See the pkg-config man page for more details.
 To get pkg-config, see <http://pkg-config.freedesktop.org/>.
 See \`config.log' for more details" "$LINENO" 5; }
 else
-	libobjc_CFLAGS=$pkg_cv_libobjc_CFLAGS
-	libobjc_LIBS=$pkg_cv_libobjc_LIBS
+        libobjc_CFLAGS=$pkg_cv_libobjc_CFLAGS
+        libobjc_LIBS=$pkg_cv_libobjc_LIBS
         { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }
 
@@ -7694,14 +7694,14 @@ else
         _pkg_short_errors_supported=no
 fi
         if test $_pkg_short_errors_supported = yes; then
-	        libobjc_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libobjc" 2>&1`
+                libobjc_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libobjc" 2>&1`
         else
-	        libobjc_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libobjc" 2>&1`
+                libobjc_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libobjc" 2>&1`
         fi
-	# Put the nasty error message in config.log where it belongs
-	echo "$libobjc_PKG_ERRORS" >&5
+        # Put the nasty error message in config.log where it belongs
+        echo "$libobjc_PKG_ERRORS" >&5
 
-	as_fn_error $? "Package requirements (libobjc) were not met:
+        as_fn_error $? "Package requirements (libobjc) were not met:
 
 $libobjc_PKG_ERRORS
 
@@ -7714,7 +7714,7 @@ See the pkg-config man page for more details." "$LINENO" 5
 elif test $pkg_failed = untried; then
         { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
 printf "%s\n" "no" >&6; }
-	{ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+        { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
 printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
 as_fn_error $? "The pkg-config script could not be found or is too old.  Make sure it
 is in your PATH or set the PKG_CONFIG environment variable to the full
@@ -7727,8 +7727,8 @@ See the pkg-config man page for more details.
 To get pkg-config, see <http://pkg-config.freedesktop.org/>.
 See \`config.log' for more details" "$LINENO" 5; }
 else
-	libobjc_CFLAGS=$pkg_cv_libobjc_CFLAGS
-	libobjc_LIBS=$pkg_cv_libobjc_LIBS
+        libobjc_CFLAGS=$pkg_cv_libobjc_CFLAGS
+        libobjc_LIBS=$pkg_cv_libobjc_LIBS
         { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }
 
@@ -7737,8 +7737,8 @@ fi
 fi
 
 else
-	libobjc_CFLAGS=$pkg_cv_libobjc_CFLAGS
-	libobjc_LIBS=$pkg_cv_libobjc_LIBS
+        libobjc_CFLAGS=$pkg_cv_libobjc_CFLAGS
+        libobjc_LIBS=$pkg_cv_libobjc_LIBS
         { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }
 
@@ -8787,6 +8787,47 @@ rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
 fi
 
   fi
+elif test "$host_os" = linux-musl; then
+  LIBS="$OBJCRT -lpthread"
+  if test "$cross_compiling" = yes
+then :
+  objc_threaded="-lpthread"
+else $as_nop
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include "config_thread.m"
+_ACEOF
+if ac_fn_c_try_run "$LINENO"
+then :
+  objc_threaded="-lpthread"
+else $as_nop
+  objc_threaded=""
+fi
+rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+  conftest.$ac_objext conftest.beam conftest.$ac_ext
+fi
+
+  if test x"$objc_threaded" = x""; then
+    LIBS="$OBJCRT"
+    if test "$cross_compiling" = yes
+then :
+  objc_threaded="works"
+else $as_nop
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include "config_thread.m"
+_ACEOF
+if ac_fn_c_try_run "$LINENO"
+then :
+  objc_threaded="works"
+else $as_nop
+  objc_threaded=""
+fi
+rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+  conftest.$ac_objext conftest.beam conftest.$ac_ext
+fi
+
+  fi
 elif test "`echo $host_os|sed 's/[0-9].*//'|sed s/elf//`" = freebsd; then
   LIBS="-pthread $OBJCRT"
   if test "$cross_compiling" = yes
@@ -9291,7 +9332,6 @@ fi
 
 
 
-
     ac_fn_c_check_func "$LINENO" "__objc_load" "ac_cv_func___objc_load"
 if test "x$ac_cv_func___objc_load" = xyes
 then :
@@ -9366,39 +9406,41 @@ fi
 # If we determined that the user wants the gnustep-2.0 ABI, check for potential linker problems.
 if test $gs_cv_runtime_abi = 'gnustep-2.0'; then
 
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking which linker is being used" >&5
+printf %s "checking which linker is being used... " >&6; }
 
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for an gnustep-2.0 ABI compatible linker" >&5
-printf %s "checking for an gnustep-2.0 ABI compatible linker... " >&6; }
-if test ${gs_cv_abi20_linker+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
-          gs_cv_abi20_linker="unkown"
+  # Write a simple test program to a file.
+  echo 'int main() { return 0; }' > conftest.c
 
-        gs_cv_abi20_linker_prog=$($CC --print-prog-name=ld)
-        if $gs_cv_abi20_linker_prog --version | $GREP -q 'GNU ld'; then
-            gs_cv_abi20_linker="unlikely (GNU ld)"
-        elif $gs_cv_abi20_linker_prog --version | $GREP -q 'GNU gold'; then
-            gs_cv_abi20_linker="yes (GNU gold)"
-        elif $gs_cv_abi20_linker_prog --version | $GREP -q 'LLD'; then
-            gs_cv_abi20_linker="yes (LLD)"
-        fi
+  # Try compiling with verbose output to capture linker information.
+  $CC $CFLAGS $LDFLAGS -o conftest conftest.c -Wl,--verbose > compile.log 2>&1
 
+  # Determine which linker is being used based on the log.
+  linker="unknown"  # Default to unknown.
+  if grep -q "GNU ld" compile.log; then
+    linker="GNU ld"
+  # GNU gold does not print a header line, so we just check for "gold".
+  elif grep -q "gold" compile.log; then
+    linker="GNU gold"
+  # LLD does not print a header line, so we just check for "lld".
+  elif grep -q "lld" compile.log; then
+    linker="lld"
+  fi
 
-fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $gs_cv_abi20_linker" >&5
-printf "%s\n" "$gs_cv_abi20_linker" >&6; }
-    if echo "$gs_cv_abi20_linker" | $GREP -q '^yes'; then
-        _gs_abi20_linker=yes
-    else
-        _gs_abi20_linker=no
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: The detected linker might not produce working Objective-C binaries using the gnustep-2.0 ABI. Consider using gold or LLD." >&5
-printf "%s\n" "$as_me: WARNING: The detected linker might not produce working Objective-C binaries using the gnustep-2.0 ABI. Consider using gold or LLD." >&2;}
-    fi
-    if test "x$_gs_abi20_linker" = x"yes"
-then :
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $linker" >&5
+printf "%s\n" "$linker" >&6; }
 
-fi
+  # Clean up the test artifacts.
+  rm -f conftest.c conftest
+
+  # Based on the identified linker, we may want to display a warning or take other actions.
+  if test "x$linker" = "xGNU ld"; then
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: The detected linker (GNU ld) might not produce working Objective-C binaries using the gnustep-2.0 ABI. Consider using GNU gold or LLD." >&5
+printf "%s\n" "$as_me: WARNING: The detected linker (GNU ld) might not produce working Objective-C binaries using the gnustep-2.0 ABI. Consider using GNU gold or LLD." >&2;}
+  elif test "x$linker" = "xunknown" && test -n "$explicit_linker_flag"; then
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: Unable to confirm if the explicitly specified linker '$explicit_linker_flag' is compatible with the gnustep-2.0 ABI." >&5
+printf "%s\n" "$as_me: WARNING: Unable to confirm if the explicitly specified linker '$explicit_linker_flag' is compatible with the gnustep-2.0 ABI." >&2;}
+  fi
 
 fi
 # Do not restore LIBS and CFLAGS yet as we need to test if the

--- a/m4/gs_check_abi20_linker.m4
+++ b/m4/gs_check_abi20_linker.m4
@@ -10,7 +10,6 @@
 AC_DEFUN([GS_CHECK_ABI20_LINKER], [
   AC_MSG_CHECKING([which linker is being used])
 
-  # Write a simple test program to a file.
   echo 'int main() { return 0; }' > conftest.c
 
   # Try compiling with verbose output to capture linker information.


### PR DESCRIPTION
See: #36 

Instead of just printing the path for ld, we compile a small test program with the CFLAGS and LDFLAGS from configure and increased verbosity, and grep the linker output.

Configure script was rebuild using `autoreconf -vi`.

Demonstration:
## LLD
```sh
./configure --with-layout=debian \
 --enable-native-objc-exceptions  \
--enable-objc-arc \
--prefix=/usr \
--with-runtime-abi=gnustep-2.0 \
--with-library-combo=ng-gnu-gnu \
LDFLAGS="-fuse-ld=lld -L/usr/lib/aarch64-linux-gnu" SHELLPROG=/bin/bash GNUMAKE=make
```
```plaintext
[...]
checking for runtime ABI... gnustep-2.0
checking which linker is being used... lld
checking whether the compiler supports native ObjC exceptions... yes
[...]
```

## GNU Gold
```sh
./configure --with-layout=debian \
 --enable-native-objc-exceptions  \
--enable-objc-arc \
--prefix=/usr \
--with-runtime-abi=gnustep-2.0 \
--with-library-combo=ng-gnu-gnu \
LDFLAGS="-fuse-ld=gold -L/usr/lib/aarch64-linux-gnu" SHELLPROG=/bin/bash GNUMAKE=make
```
```plaintext
[...]
checking whether runtime library supports the gnustep-2.0 ABI... yes
checking for runtime ABI... gnustep-2.0
checking which linker is being used... GNU gold
checking whether the compiler supports native ObjC exceptions... yes
[...]
```

## Otherwise
```plaintext
[...]
checking for runtime ABI... gnustep-2.0
checking which linker is being used... GNU ld
configure: WARNING: The detected linker (GNU ld) might not produce working Objective-C binaries using the gnustep-2.0 ABI. Consider using GNU gold or LLD.
checking whether the compiler supports native ObjC exceptions... yes
[...]
```