### PR TITLE
Ensure -gcodeview on Windows MSVC

### DIFF
--- a/common.make
+++ b/common.make
@@ -745,7 +745,7 @@ ifeq ($(debug), yes)
   ADDITIONAL_FLAGS := $(filter-out -O%, $(ADDITIONAL_FLAGS))
   # If OPTFLAG does not already include -g, add it here.
   ifneq ($(filter -g, $(OPTFLAG)), -g)
-    ADDITIONAL_FLAGS += -g
+    OPTFLAG += -g
   endif
   # Add standard debug compiler flags.
   ADDITIONAL_FLAGS += -DDEBUG -fno-omit-frame-pointer
@@ -757,6 +757,16 @@ else
 
   # The following is for Java.
   INTERNAL_JAVACFLAGS += -O
+endif
+
+# On Windows MSVC we also need -gcodeview to generate debug symbols, and since
+# Autoconf does not add it we add it here.
+ifeq ($(GNUSTEP_TARGET_OS), windows)
+  ifeq ($(filter -g, $(OPTFLAG)), -g)
+    ifneq ($(filter -gcodeview, $(OPTFLAG)), -gcodeview)
+      OPTFLAG += -gcodeview
+    endif
+  endif
 endif
 
 ifeq ($(warn), no)


### PR DESCRIPTION
On Windows MSVC `-gcodeview` is required in addition to `-g` in order to generate full debug symbols. This enables debugging Objective-C code with native Windows debugging tools such as Visual Studio or WinDBG (more info about CodeView support in LLVM can e.g. be found [here](https://llvm.org/devmtg/2016-11/Slides/Kleckner-CodeViewInLLVM.pdf)).

This change always adds the flag if `-g` is found in `OPTFLAG`.