### PR TITLE
Bump Objective-C Runtime Version for libobjc2 and add installation instructions

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -61,7 +61,7 @@ Here is an example with the runtime version set to 2.2.
 Please note that we explicitly enable some features such as objc-arc that might
 be infered from the runtime version.
 
-      ./configure
+      ./configure \
 		  --enable-native-objc-exceptions \
   		  --enable-objc-arc \
   		  --with-runtime-abi=gnustep-2.2 \

--- a/INSTALL
+++ b/INSTALL
@@ -20,7 +20,10 @@ particular operating system and CPU. These instructions come with the
 GNUstep-HOWTO and are also located at the GNUstep web site at
 <http://www.gnustep.org>.
 
-   Quick installation instructions:
+1.1.1 Quick Installation Instructions
+---------------------
+
+To build and install the GNUstep Makefiles, run the following commands:
 
      ./configure
      make
@@ -43,6 +46,27 @@ filesystem layout).
      cd Documentation
      make
      make install
+
+1.1.2 Enabling Modern Objective-C Features
+---------------------
+
+GNUstep supports the legacy GCC runtime, and the modern libobjc2 runtime with
+Objective-C 2.0 Features such as ARC, Blocks (closures),  Synthesised property
+accessors, Efficient support for @synchronized() and more.
+
+   libobjc2 requires building with clang. If you've installed both clang and libobjc2
+you can configure GNUstep Make to use the newer runtime and features.
+Here is an example with the runtime version set to 2.2.
+(Set it to the last libobjc2 version to benefit from possible changes in Clang CodeGen).
+Please note that we explicitly enable some features such as objc-arc that might
+be infered from the runtime version.
+
+      ./configure
+		  --enable-native-objc-exceptions \
+  		  --enable-objc-arc \
+  		  --with-runtime-abi=gnustep-2.2 \
+  		  --with-library-combo=ng-gnu-gnu \
+  	CC="clang" CXX="clang++" CPP="clang -E" LDFLAGS="-fuse-ld=lld"
 
 1.2 Configuration
 =================

--- a/configure
+++ b/configure
@@ -4886,11 +4886,11 @@ if test x$ac_prog_cxx_stdcxx = xno
 then :
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CXX option to enable C++11 features" >&5
 printf %s "checking for $CXX option to enable C++11 features... " >&6; }
-if test ${ac_cv_prog_cxx_11+y}
+if test ${ac_cv_prog_cxx_cxx11+y}
 then :
   printf %s "(cached) " >&6
 else $as_nop
-  ac_cv_prog_cxx_11=no
+  ac_cv_prog_cxx_cxx11=no
 ac_save_CXX=$CXX
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -4932,11 +4932,11 @@ if test x$ac_prog_cxx_stdcxx = xno
 then :
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CXX option to enable C++98 features" >&5
 printf %s "checking for $CXX option to enable C++98 features... " >&6; }
-if test ${ac_cv_prog_cxx_98+y}
+if test ${ac_cv_prog_cxx_cxx98+y}
 then :
   printf %s "(cached) " >&6
 else $as_nop
-  ac_cv_prog_cxx_98=no
+  ac_cv_prog_cxx_cxx98=no
 ac_save_CXX=$CXX
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -7542,12 +7542,12 @@ else
         _pkg_short_errors_supported=no
 fi
         if test $_pkg_short_errors_supported = yes; then
-	        libobjc_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libobjc >= 2" 2>&1`
+                libobjc_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libobjc >= 2" 2>&1`
         else
-	        libobjc_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libobjc >= 2" 2>&1`
+                libobjc_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libobjc >= 2" 2>&1`
         fi
-	# Put the nasty error message in config.log where it belongs
-	echo "$libobjc_PKG_ERRORS" >&5
+        # Put the nasty error message in config.log where it belongs
+        echo "$libobjc_PKG_ERRORS" >&5
 
 
             if test -n "$PKG_CONFIG" && \
@@ -7609,14 +7609,14 @@ else
         _pkg_short_errors_supported=no
 fi
         if test $_pkg_short_errors_supported = yes; then
-	        libobjc_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libobjc" 2>&1`
+                libobjc_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libobjc" 2>&1`
         else
-	        libobjc_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libobjc" 2>&1`
+                libobjc_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libobjc" 2>&1`
         fi
-	# Put the nasty error message in config.log where it belongs
-	echo "$libobjc_PKG_ERRORS" >&5
+        # Put the nasty error message in config.log where it belongs
+        echo "$libobjc_PKG_ERRORS" >&5
 
-	as_fn_error $? "Package requirements (libobjc) were not met:
+        as_fn_error $? "Package requirements (libobjc) were not met:
 
 $libobjc_PKG_ERRORS
 
@@ -7629,7 +7629,7 @@ See the pkg-config man page for more details." "$LINENO" 5
 elif test $pkg_failed = untried; then
         { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
 printf "%s\n" "no" >&6; }
-	{ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+        { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
 printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
 as_fn_error $? "The pkg-config script could not be found or is too old.  Make sure it
 is in your PATH or set the PKG_CONFIG environment variable to the full
@@ -7642,8 +7642,8 @@ See the pkg-config man page for more details.
 To get pkg-config, see <http://pkg-config.freedesktop.org/>.
 See \`config.log' for more details" "$LINENO" 5; }
 else
-	libobjc_CFLAGS=$pkg_cv_libobjc_CFLAGS
-	libobjc_LIBS=$pkg_cv_libobjc_LIBS
+        libobjc_CFLAGS=$pkg_cv_libobjc_CFLAGS
+        libobjc_LIBS=$pkg_cv_libobjc_LIBS
         { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }
 
@@ -7714,14 +7714,14 @@ else
         _pkg_short_errors_supported=no
 fi
         if test $_pkg_short_errors_supported = yes; then
-	        libobjc_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libobjc" 2>&1`
+                libobjc_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libobjc" 2>&1`
         else
-	        libobjc_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libobjc" 2>&1`
+                libobjc_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libobjc" 2>&1`
         fi
-	# Put the nasty error message in config.log where it belongs
-	echo "$libobjc_PKG_ERRORS" >&5
+        # Put the nasty error message in config.log where it belongs
+        echo "$libobjc_PKG_ERRORS" >&5
 
-	as_fn_error $? "Package requirements (libobjc) were not met:
+        as_fn_error $? "Package requirements (libobjc) were not met:
 
 $libobjc_PKG_ERRORS
 
@@ -7734,7 +7734,7 @@ See the pkg-config man page for more details." "$LINENO" 5
 elif test $pkg_failed = untried; then
         { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
 printf "%s\n" "no" >&6; }
-	{ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+        { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
 printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
 as_fn_error $? "The pkg-config script could not be found or is too old.  Make sure it
 is in your PATH or set the PKG_CONFIG environment variable to the full
@@ -7747,8 +7747,8 @@ See the pkg-config man page for more details.
 To get pkg-config, see <http://pkg-config.freedesktop.org/>.
 See \`config.log' for more details" "$LINENO" 5; }
 else
-	libobjc_CFLAGS=$pkg_cv_libobjc_CFLAGS
-	libobjc_LIBS=$pkg_cv_libobjc_LIBS
+        libobjc_CFLAGS=$pkg_cv_libobjc_CFLAGS
+        libobjc_LIBS=$pkg_cv_libobjc_LIBS
         { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }
 
@@ -7757,8 +7757,8 @@ fi
 fi
 
 else
-	libobjc_CFLAGS=$pkg_cv_libobjc_CFLAGS
-	libobjc_LIBS=$pkg_cv_libobjc_LIBS
+        libobjc_CFLAGS=$pkg_cv_libobjc_CFLAGS
+        libobjc_LIBS=$pkg_cv_libobjc_LIBS
         { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }
 
@@ -9192,7 +9192,7 @@ if test x"$USE_ARC" = x"yes"; then
   # What we want to do: set USE_ARC to yes if we can compile
   # something with -fobjc-arc.
   CFLAGS_no_arc="$CFLAGS"
-  CFLAGS="$CFLAGS -fobjc-runtime=gnustep-1.8 -fobjc-arc"
+  CFLAGS="$CFLAGS -fobjc-runtime=gnustep-2.2 -fobjc-arc"
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -9363,8 +9363,8 @@ fi
 
 
 
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether runtime library supports the gnustep-2.0 ABI" >&5
-printf %s "checking whether runtime library supports the gnustep-2.0 ABI... " >&6; }
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether runtime library supports the gnustep-2.x ABI" >&5
+printf %s "checking whether runtime library supports the gnustep-2.x ABI... " >&6; }
 if test ${gs_cv_libobjc_abi_20+y}
 then :
   printf %s "(cached) " >&6
@@ -9387,13 +9387,13 @@ printf "%s\n" "$gs_cv_libobjc_abi_20" >&6; }
 
    case "$OBJC_RUNTIME_LIB" in
         gnu) default_runtime_abi=gcc         ;;
-        ng)  default_runtime_abi=gnustep-1.8 ;;
+        ng)  default_runtime_abi=gnustep-2.2 ;;
         *)   default_runtime_abi="(unknown)" ;;
     esac
     if test ! x"" = x""; then
         default_runtime_abi=""
     elif test x"$OBJC_RUNTIME_LIB" = x"ng" -a x"$libobjc_SUPPORTS_ABI20" = x"yes" -a x"$CLANG_CC" = x"yes" -a "${gs_cv_gcc_major_version}" -ge "8"; then
-        default_runtime_abi=gnustep-2.0
+        default_runtime_abi=gnustep-2.2
     fi
 
 # Check whether --with-runtime-abi was given.

--- a/configure.ac
+++ b/configure.ac
@@ -1298,7 +1298,7 @@ if test x"$USE_ARC" = x"yes"; then
   # What we want to do: set USE_ARC to yes if we can compile
   # something with -fobjc-arc.
   CFLAGS_no_arc="$CFLAGS"
-  CFLAGS="$CFLAGS -fobjc-runtime=gnustep-1.8 -fobjc-arc"
+  CFLAGS="$CFLAGS -fobjc-runtime=gnustep-2.2 -fobjc-arc"
   AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
 /* Note that we never execute this code so it does not really matter
    what it is.  We are testing that the compiler accepts the

--- a/library-combo.make
+++ b/library-combo.make
@@ -47,7 +47,7 @@ ifeq ($(OBJC_RUNTIME_LIB), ng)
     ifneq ($(DEFAULT_OBJC_RUNTIME_ABI),)
       RUNTIME_VERSION=$(DEFAULT_OBJC_RUNTIME_ABI)
    else
-     RUNTIME_VERSION=gnustep-1.8
+     RUNTIME_VERSION=gnustep-2.2
    endif
   endif
   RUNTIME_FLAG = -fobjc-runtime=$(RUNTIME_VERSION) -fblocks

--- a/m4/gs_objc_runtime.m4
+++ b/m4/gs_objc_runtime.m4
@@ -254,7 +254,7 @@ AC_DEFUN([GS_CHECK_OBJC_RUNTIME], [
 ])
 
 
-# Helper macro for checking gnustep-2.0 ABI support in libobjc via the __objc_load macro
+# Helper macro for checking gnustep-2.x ABI support in libobjc via the __objc_load macro
 AC_DEFUN([_GS_HAVE_OBJC_LOAD], [
     AC_REQUIRE([GS_CHECK_OBJC_RUNTIME])
     AC_CHECK_FUNC([__objc_load])
@@ -266,11 +266,11 @@ AC_DEFUN([_GS_HAVE_OBJC_LOAD], [
 #
 # DESCRIPTION
 # 
-# Checks for support for the gnustep-2.0 ABI in the runtime library. Sets the `libobjc_SUPPORTS_ABI20' variable.
+# Checks for support for the gnustep-2.x ABI in the runtime library. Sets the `libobjc_SUPPORTS_ABI20' variable.
 AC_DEFUN([GS_CHECK_RUNTIME_ABI20_SUPPORT], [
     AC_REQUIRE([GS_CHECK_OBJC_RUNTIME])
     AC_REQUIRE([_GS_HAVE_OBJC_LOAD])
-    AC_CACHE_CHECK([whether runtime library supports the gnustep-2.0 ABI],
+    AC_CACHE_CHECK([whether runtime library supports the gnustep-2.x ABI],
         [gs_cv_libobjc_abi_20], [
             if test x"$libobjc_SUPPORTS_ABI20" = x""; then
                 gs_cv_libobjc_abi_20=$ac_cv_func___objc_load

--- a/m4/gs_runtime_abi.m4
+++ b/m4/gs_runtime_abi.m4
@@ -13,13 +13,13 @@ AC_DEFUN([GS_RUNTIME_ABI],dnl
    AC_REQUIRE([GS_CHECK_GCC_VERSION])
    case "$OBJC_RUNTIME_LIB" in
         gnu) default_runtime_abi=gcc         ;;
-        ng)  default_runtime_abi=gnustep-1.8 ;;
+        ng)  default_runtime_abi=gnustep-2.2 ;;
         *)   default_runtime_abi="(unknown)" ;;
     esac
     if test ! x"$1" = x""; then
         default_runtime_abi="$1"
     elif test x"$OBJC_RUNTIME_LIB" = x"ng" -a x"$libobjc_SUPPORTS_ABI20" = x"yes" -a x"$CLANG_CC" = x"yes" -a "${gs_cv_gcc_major_version}" -ge "8"; then
-        default_runtime_abi=gnustep-2.0
+        default_runtime_abi=gnustep-2.2
     fi
     AC_ARG_WITH([runtime-abi],
         [AS_HELP_STRING([--with-runtime-abi], [


### PR DESCRIPTION
This was tested on Ubuntu 23.10 (aarch64) and Windows 11 Pro.