### PR TITLE
Initial address sanitisation support

### DIFF
--- a/common.make
+++ b/common.make
@@ -769,6 +769,22 @@ ifeq ($(GNUSTEP_TARGET_OS), windows)
   endif
 endif
 
+# Sanitization must be enabled explicitly and shall _not_ be used in production,
+# as it may leak sensitive info or result in privilege escalation due to unchecked
+# use of variables (https://www.openwall.com/lists/oss-security/2016/02/17/9).
+
+ifeq ($(asan), yes)
+  ADDITIONAL_FLAGS += -fsanitize=address
+  # We use the clang or gcc to drive the linking process. The driver will
+  # add the required runtime libraries for address sanitizer.
+  INTERNAL_LDFLAGS += -fsanitize=address
+
+  # Not omitting the frame pointer results in more readable stack traces
+  ifneq ($(filter -fno-omit-frame-pointer, $(ADDTIONAL_FLAGS)), -fno-omit-frame-pointer)
+    ADDITIONAL_FLAGS += -fno-omit-frame-pointer
+  endif
+endif
+
 ifeq ($(warn), no)
   ADDITIONAL_FLAGS += -UGSWARN
 else


### PR DESCRIPTION
# Introducing address sanitization support

For more information on address sanitization read https://clang.llvm.org/docs/AddressSanitizer.html or https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html#index-fsanitize_003daddress.

Address sanitization can be turned on with the new `asan` flag in GNUstep Make: `make asan=yes`.

## Caveats

The GNUstep Base library currently leaks memory upon program exit which makes analysis a bit cumbersome. We should improve on this, and encourage users of GNUstep make to use sanitization.

###  Demo

```
include $(GNUSTEP_MAKEFILES)/common.make

TOOL_NAME = demo

demo_OBJC_FILES = demo.m

-include GNUmakefile.preamble

include $(GNUSTEP_MAKEFILES)/tool.make

-include GNUmakefile.postamble
```

```
#import <Foundation/Foundation.h>

int main() {
	NSAutoreleasePool *arp = [NSAutoreleasePool new];
	[arp drain];
	return 0;
}
```

```sh
$ make asan=yes
$ ./obj/demo

=================================================================
==42402==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 40 byte(s) in 1 object(s) allocated from:
    #0 0xaaaadfe673d0 in calloc (/home/hmelder/example-gnustep-project/obj/demo+0xd73d0) (BuildId: af853ff0eca3f6f0e09b182830f87b00b389c0ea)
    #1 0xffffaf3c8df0 in allocate_class /home/hmelder/libobjc2/gc_none.c:19:3
    #2 0xffffaf3cb8ac in class_createInstance /home/hmelder/libobjc2/runtime.c:361:11
    #3 0xffffaf6d36dc in NSAllocateObject (/usr/gnustep/lib/libgnustep-base.so.1.30+0x2d36dc) (BuildId: 4e1ccc5c5276fba035c2814c49a9837ee5e5811e)
    #4 0xffffaf63dd40 in _c_NSDataStatic__allocWithZone_ NSData.m
    #5 0xffffaf637914 in _c_NSData__dataWithBytesNoCopy_length_ NSData.m
    #6 0xffffaf746088 in _i_NSString__dataUsingEncoding_allowLossyConversion_ NSString.m
    #7 0xffffaf745e10 in _i_NSString__dataUsingEncoding_ NSString.m
    #8 0xffffaf745748 in _i_NSString__getCString_maxLength_encoding_ NSString.m
    #9 0xffffaf6d32b8 in NSClassFromString (/usr/gnustep/lib/libgnustep-base.so.1.30+0x2d32b8) (BuildId: 4e1ccc5c5276fba035c2814c49a9837ee5e5811e)
    #10 0xffffaf5bfb8c in setup GSString.m
    #11 0xffffaf5bf958 in _c_GSPlaceholderString__initialize GSString.m
    #12 0xffffaf3c7e10 in objc_send_initialize /home/hmelder/libobjc2/dtable.c:859:2
    #13 0xffffaf3ccdf8 in objc_msg_lookup_internal /home/hmelder/libobjc2/sendmsg2.c:112:4
    #14 0xffffaf3ccdf8 in slowMsgLookup /home/hmelder/libobjc2/sendmsg2.c:163:9
    #15 0xffffaf3d05f8 in objc_msgSend_stret /home/hmelder/libobjc2/objc_msgSend.aarch64.S:210
    #16 0xffffaf73b354 in _c_NSString__initialize NSString.m
    #17 0xffffaf3c7e10 in objc_send_initialize /home/hmelder/libobjc2/dtable.c:859:2
    #18 0xffffaf3ccdf8 in objc_msg_lookup_internal /home/hmelder/libobjc2/sendmsg2.c:112:4
    #19 0xffffaf3ccdf8 in slowMsgLookup /home/hmelder/libobjc2/sendmsg2.c:163:9
    #20 0xffffaf3d05f8 in objc_msgSend_stret /home/hmelder/libobjc2/objc_msgSend.aarch64.S:210
    #21 0xffffaf6d3b2c in _c_NSObject__initialize NSObject.m
    #22 0xffffaf3c7e10 in objc_send_initialize /home/hmelder/libobjc2/dtable.c:859:2
    #23 0xffffaf3c7c58 in objc_send_initialize /home/hmelder/libobjc2/dtable.c:745:3
    #24 0xffffaf3ccdf8 in objc_msg_lookup_internal /home/hmelder/libobjc2/sendmsg2.c:112:4
    #25 0xffffaf3ccdf8 in slowMsgLookup /home/hmelder/libobjc2/sendmsg2.c:163:9
    #26 0xffffaf3d05f8 in objc_msgSend_stret /home/hmelder/libobjc2/objc_msgSend.aarch64.S:210
    #27 0xaaaadfea691c in main (/home/hmelder/example-gnustep-project/obj/demo+0x11691c) (BuildId: af853ff0eca3f6f0e09b182830f87b00b389c0ea)
    #28 0xffffaf112290  (/lib/aarch64-linux-gnu/libc.so.6+0x22290) (BuildId: 5c8f998f04145b99f2b808e5679fee4bb785e2a5)
    #29 0xffffaf112374 in __libc_start_main (/lib/aarch64-linux-gnu/libc.so.6+0x22374) (BuildId: 5c8f998f04145b99f2b808e5679fee4bb785e2a5)
    #30 0xaaaadfdc472c in _start (/home/hmelder/example-gnustep-project/obj/demo+0x3472c) (BuildId: af853ff0eca3f6f0e09b182830f87b00b389c0ea)

Indirect leak of 17 byte(s) in 1 object(s) allocated from:
    #0 0xaaaadfe67204 in malloc (/home/hmelder/example-gnustep-project/obj/demo+0xd7204) (BuildId: af853ff0eca3f6f0e09b182830f87b00b389c0ea)
    #1 0xffffaf7a6f70 in default_malloc NSZone.m
    #2 0xffffaf7a6d50 in NSZoneMalloc (/usr/gnustep/lib/libgnustep-base.so.1.30+0x3a6d50) (BuildId: 4e1ccc5c5276fba035c2814c49a9837ee5e5811e)
    #3 0xffffaf8091cc in GSFromUnicode (/usr/gnustep/lib/libgnustep-base.so.1.30+0x4091cc) (BuildId: 4e1ccc5c5276fba035c2814c49a9837ee5e5811e)
    #4 0xffffaf746058 in _i_NSString__dataUsingEncoding_allowLossyConversion_ NSString.m
    #5 0xffffaf745e10 in _i_NSString__dataUsingEncoding_ NSString.m
    #6 0xffffaf745748 in _i_NSString__getCString_maxLength_encoding_ NSString.m
    #7 0xffffaf6d32b8 in NSClassFromString (/usr/gnustep/lib/libgnustep-base.so.1.30+0x2d32b8) (BuildId: 4e1ccc5c5276fba035c2814c49a9837ee5e5811e)
    #8 0xffffaf5bfb8c in setup GSString.m
    #9 0xffffaf5bf958 in _c_GSPlaceholderString__initialize GSString.m
    #10 0xffffaf3c7e10 in objc_send_initialize /home/hmelder/libobjc2/dtable.c:859:2
    #11 0xffffaf3ccdf8 in objc_msg_lookup_internal /home/hmelder/libobjc2/sendmsg2.c:112:4
    #12 0xffffaf3ccdf8 in slowMsgLookup /home/hmelder/libobjc2/sendmsg2.c:163:9
    #13 0xffffaf3d05f8 in objc_msgSend_stret /home/hmelder/libobjc2/objc_msgSend.aarch64.S:210
    #14 0xffffaf73b354 in _c_NSString__initialize NSString.m
    #15 0xffffaf3c7e10 in objc_send_initialize /home/hmelder/libobjc2/dtable.c:859:2
    #16 0xffffaf3ccdf8 in objc_msg_lookup_internal /home/hmelder/libobjc2/sendmsg2.c:112:4
    #17 0xffffaf3ccdf8 in slowMsgLookup /home/hmelder/libobjc2/sendmsg2.c:163:9
    #18 0xffffaf3d05f8 in objc_msgSend_stret /home/hmelder/libobjc2/objc_msgSend.aarch64.S:210
    #19 0xffffaf6d3b2c in _c_NSObject__initialize NSObject.m
    #20 0xffffaf3c7e10 in objc_send_initialize /home/hmelder/libobjc2/dtable.c:859:2
    #21 0xffffaf3c7c58 in objc_send_initialize /home/hmelder/libobjc2/dtable.c:745:3
    #22 0xffffaf3ccdf8 in objc_msg_lookup_internal /home/hmelder/libobjc2/sendmsg2.c:112:4
    #23 0xffffaf3ccdf8 in slowMsgLookup /home/hmelder/libobjc2/sendmsg2.c:163:9
    #24 0xffffaf3d05f8 in objc_msgSend_stret /home/hmelder/libobjc2/objc_msgSend.aarch64.S:210
    #25 0xaaaadfea691c in main (/home/hmelder/example-gnustep-project/obj/demo+0x11691c) (BuildId: af853ff0eca3f6f0e09b182830f87b00b389c0ea)
    #26 0xffffaf112290  (/lib/aarch64-linux-gnu/libc.so.6+0x22290) (BuildId: 5c8f998f04145b99f2b808e5679fee4bb785e2a5)
    #27 0xffffaf112374 in __libc_start_main (/lib/aarch64-linux-gnu/libc.so.6+0x22374) (BuildId: 5c8f998f04145b99f2b808e5679fee4bb785e2a5)
    #28 0xaaaadfdc472c in _start (/home/hmelder/example-gnustep-project/obj/demo+0x3472c) (BuildId: af853ff0eca3f6f0e09b182830f87b00b389c0ea)

```