### PR TITLE
CODEOWNERS: Add a section to take codeownership of 'automatic' deb rules.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,3 +3,9 @@
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
 *       @rfm
+
+# Rules to produce files for a Debian package for an arbitrary lib, app, tool,
+# etc, by providing 'debfile' and 'deb' targets.
+bake_debian_files.sh	@ivucica
+Master/deb.make	@ivucica
+


### PR DESCRIPTION
Add a section for myself to take codeownership of 'automatic' deb rules.

This will document whom to talk to, possibly raise awareness, and ensure pull requests end up in the right place.