### PR TITLE
Adding layout for Gershwin Desktop environment

### DIFF
--- a/FilesystemLayouts/gershwin
+++ b/FilesystemLayouts/gershwin
@@ -1,0 +1,90 @@
+#
+# Gershwin Filesystem Layout
+#
+# This is the layout for the Gershwin Desktop Environment. It has
+# been created to make things easier for packagers. It is very
+# similar to the GNUstep layout, but there are some key differences.
+# 
+# First, the prefix is designed to be the root of the filesystem.
+# It is set this way while being entirely self-contained. 
+#
+# Second, each domain has users to distinguish between Local, 
+# Network, and System users, which may be used for service accounts. 
+#
+# Third, more things are tucked under Library so each domain has 
+# Applications and Library for consistency. This is done for several 
+# reasons. 
+#
+# The first is that Gershwin supports a client-and-server computing model. 
+# The second is that Gershwin provides the ability to install GNUstep
+# Applications outside of the operating system’s packaging facilities.
+# These applications can be installed by a user without any elevated
+# credentials or by an administrator in the local system or network domain.
+#
+# To support these mechanisms and convince distributions to accept
+# root-prefix-driven installations, a new layout was needed. The layout is
+# essential to providing the feature sets described above.
+
+GNUSTEP_DEFAULT_PREFIX=/
+
+GNUSTEP_SYSTEM_USERS_DIR=/System/Users
+GNUSTEP_NETWORK_USERS_DIR=/Network/Users
+GNUSTEP_LOCAL_USERS_DIR=/Local/Users
+
+GNUSTEP_MAKEFILES=/System/Library/Makefiles
+GNUSTEP_CORESERVICES=/System/Library/CoreServices
+GNUSTEP_CORESERVICES_APPS=/System/Library/CoreServices/Applications
+
+GNUSTEP_SYSTEM_APPS=/System/Applications
+GNUSTEP_SYSTEM_ADMIN_APPS=/System/Applications/Admin
+GNUSTEP_SYSTEM_UTILS_APPS=/System/Applications/Utilities
+GNUSTEP_SYSTEM_WEB_APPS=/System/Library/WebApplications
+GNUSTEP_SYSTEM_TOOLS=/System/Library/Tools
+GNUSTEP_SYSTEM_ADMIN_TOOLS=/System/Library/Tools/Admin
+GNUSTEP_SYSTEM_LIBRARY=/System/Library
+GNUSTEP_SYSTEM_HEADERS=/System/Library/Headers
+GNUSTEP_SYSTEM_LIBRARIES=/System/Library/Libraries
+GNUSTEP_SYSTEM_DOC=/System/Library/Documentation
+GNUSTEP_SYSTEM_DOC_MAN=/System/Library/Documentation/man
+GNUSTEP_SYSTEM_DOC_INFO=/System/Library/Documentation/info
+
+GNUSTEP_NETWORK_APPS=/Network/Applications
+GNUSTEP_NETWORK_ADMIN_APPS=/Network/Applications/Admin
+GNUSTEP_NETWORK_UTILS_APPS=/Network/Applications/Utilities
+GNUSTEP_NETWORK_WEB_APPS=/Network/Library/WebApplications
+GNUSTEP_NETWORK_TOOLS=/Network/Library/Tools
+GNUSTEP_NETWORK_ADMIN_TOOLS=/Network/Library/Tools/Admin
+GNUSTEP_NETWORK_LIBRARY=/Network/Library
+GNUSTEP_NETWORK_HEADERS=/Network/Library/Headers
+GNUSTEP_NETWORK_LIBRARIES=/Network/Library/Libraries
+GNUSTEP_NETWORK_DOC=/Network/Library/Documentation
+GNUSTEP_NETWORK_DOC_MAN=/Network/Library/Documentation/man
+GNUSTEP_NETWORK_DOC_INFO=/Network/Library/Documentation/info
+
+GNUSTEP_LOCAL_APPS=/Local/Applications
+GNUSTEP_LOCAL_ADMIN_APPS=/Local/Applications/Admin
+GNUSTEP_LOCAL_UTILS_APPS=/Local/Applications/Utilities
+GNUSTEP_LOCAL_WEB_APPS=/Local/Library/WebApplications
+GNUSTEP_LOCAL_TOOLS=/Local/Library/Tools
+GNUSTEP_LOCAL_ADMIN_TOOLS=/Local/Library/Tools/Admin
+GNUSTEP_LOCAL_LIBRARY=/Local/Library
+GNUSTEP_LOCAL_HEADERS=/Local/Library/Headers
+GNUSTEP_LOCAL_LIBRARIES=/Local/Library/Libraries
+GNUSTEP_LOCAL_DOC=/Local/Library/Documentation
+GNUSTEP_LOCAL_DOC_MAN=/Local/Library/Documentation/man
+GNUSTEP_LOCAL_DOC_INFO=/Local/Library/Documentation/info
+
+GNUSTEP_USER_DIR_APPS=Applications
+GNUSTEP_USER_DIR_ADMIN_APPS=Applications/Admin
+GNUSTEP_USER_DIR_UTILS_APPS=Applications/Utilities
+GNUSTEP_USER_DIR_WEB_APPS=Library/WebApplications
+GNUSTEP_USER_DIR_TOOLS=Library/Tools
+GNUSTEP_USER_DIR_ADMIN_TOOLS=Library/Tools/Admin
+GNUSTEP_USER_DIR_LIBRARY=Library
+GNUSTEP_USER_DIR_HEADERS=Library/Headers
+GNUSTEP_USER_DIR_LIBRARIES=Library/Libraries
+GNUSTEP_USER_DIR_DOC=Library/Documentation
+GNUSTEP_USER_DIR_DOC_MAN=Library/Documentation/man
+GNUSTEP_USER_DIR_DOC_INFO=Library/Documentation/info
+GNUSTEP_USER_CONFIG_FILE=Library/Preferences/GNUstep.conf
+GNUSTEP_USER_DEFAULTS_DIR=Library/Preferences


### PR DESCRIPTION
As discussed in last months GNUstep meeting @gcasa thought it might be okay for me to commit a layout for Gershwin Desktop to tools-make.  It is documented why in the layout but I can provide additional documentation if needed.  If this needs to be discussed elsewhere such as the mailing list, or another meeting let me know.  Thanks.